### PR TITLE
Fixed Chocolatey parsing with summary containing newlines (#333)

### DIFF
--- a/source/UninstallTools/Factory/ChocolateyFactory.cs
+++ b/source/UninstallTools/Factory/ChocolateyFactory.cs
@@ -69,7 +69,7 @@ namespace UninstallTools.Factory
 
             if (string.IsNullOrEmpty(result)) return results;
 
-            var re = new System.Text.RegularExpressions.Regex(@"\n\w");
+            var re = new System.Text.RegularExpressions.Regex(@"\n\w.+\r\n Title:");
             var match = re.Match(result);
             if (!match.Success) return results;
             var begin = match.Index + 1;


### PR DESCRIPTION
Fix for #333

There are some packages with multiple newlines in their summary (e.g. previewhandlerpack), so I'm checking for the " Title:" in the following line. I tested the regex in Notepad++ on a .txt with all Chocolatey packages in the format BCU uses and the matches coincide with the number reported by chocolatey.