### PR TITLE
Update Scoop support

### DIFF
--- a/source/UninstallTools/Factory/Json/DynamicStringArrayConverter.cs
+++ b/source/UninstallTools/Factory/Json/DynamicStringArrayConverter.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace UninstallTools.Factory.Json
+{
+    /// <summary>
+    /// Handle JSON string array entry that has one dimension less or more.
+    /// </summary>
+    internal class DynamicStringArrayConverter : JsonConverter<string[]>
+    {
+        public override string[] Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            // 0-dimension
+            if (reader.TokenType == JsonTokenType.String)
+            {
+                return new[] { reader.GetString() };
+            }
+            else if (reader.TokenType == JsonTokenType.StartArray)
+            {
+                List<string> results = new();
+                while (reader.Read() && reader.TokenType != JsonTokenType.EndArray)
+                {
+                    // nested
+                    if (reader.TokenType == JsonTokenType.StartArray)
+                    {
+                        var clone = reader;
+                        _ = clone.Read();
+                        results.Add(clone.GetString()); // take first value of nested array only               
+                        reader.Skip();
+                    }
+                    // normal
+                    else if (reader.TokenType == JsonTokenType.String)
+                    {
+                        results.Add(reader.GetString());
+                    }
+                }
+                return results.ToArray();
+            }
+
+            throw new JsonException();
+        }
+
+        public override void Write(Utf8JsonWriter writer, string[] value, JsonSerializerOptions options)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/source/UninstallTools/Factory/Json/PowerShellDateTimeOffsetConverter.cs
+++ b/source/UninstallTools/Factory/Json/PowerShellDateTimeOffsetConverter.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace UninstallTools.Factory.Json
+{
+    internal class PowerShellDateTimeOffsetConverter : JsonConverter<DateTimeOffset>
+    {
+        public override DateTimeOffset Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType == JsonTokenType.String)
+            {
+                var value = reader.GetString();
+                // Windows PowerShell: /Date(1640995200000)/
+                if (value.StartsWith("/", StringComparison.Ordinal))
+                {
+                    var timestamp = long.Parse(value.Substring(6, value.Length - 8));
+                    return DateTimeOffset.FromUnixTimeMilliseconds(timestamp);
+                }
+                // PowerShell Core: 2022-01-01T00:00:00.0000000+00:00
+                else
+                {
+                    return DateTimeOffset.Parse(value);
+                }
+            }
+            // Windows PowerShell: nested { value: /Date(1640995200000)/ }
+            else if (reader.TokenType == JsonTokenType.StartObject)
+            {
+                var clone = reader;
+                reader.Skip();
+                while (clone.Read() && clone.TokenType != JsonTokenType.EndObject)
+                {
+                    if (clone.TokenType == JsonTokenType.PropertyName && clone.GetString() == "value")
+                    {
+                        _ = clone.Read();
+                        var value = clone.GetString();
+                        var timestamp = long.Parse(value.Substring(6, value.Length - 8));
+                        return DateTimeOffset.FromUnixTimeMilliseconds(timestamp);
+                    }
+                }
+            }
+
+            throw new JsonException();
+        }
+
+        public override void Write(Utf8JsonWriter writer, DateTimeOffset value, JsonSerializerOptions options)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/source/UninstallTools/Factory/ScoopFactory.cs
+++ b/source/UninstallTools/Factory/ScoopFactory.cs
@@ -75,21 +75,26 @@ namespace UninstallTools.Factory
             }
         }
 
-        private sealed record class ExportInfo(
-            //ExportBucketEntry[] Buckets,
-            ExportAppEntry[] Apps);
-        //private sealed record class ExportBucketEntry(
-        //    string Name,
-        //    string Source,
-        //    DateTimeOffset Updated,
-        //    ulong Manifests);
-        private sealed record class ExportAppEntry(
-            string Name,
-            string Version,
-            string Source,
-            DateTimeOffset Updated,
-            string Info)
+        private sealed class ExportInfo
         {
+            //public ExportBucketEntry[] Buckets { get; set; }
+            public ExportAppEntry[] Apps { get; set; }
+        }
+        //private sealed class ExportBucketEntry
+        //{
+        //    public string Name { get; set; }
+        //    public string Source { get; set; }
+        //    public DateTimeOffset Updated { get; set; }
+        //    public ulong Manifests { get; set; }
+        //}
+        private sealed class ExportAppEntry
+        {
+            public string Name { get; set; }
+            public string Version { get; set; }
+            public string Source { get; set; }
+            public DateTimeOffset Updated { get; set; }
+            public string Info { get; set; }
+
             [JsonIgnore] public bool IsPublic => Info?.Contains("Global install", StringComparison.InvariantCultureIgnoreCase) == true;
         }
 
@@ -177,23 +182,28 @@ namespace UninstallTools.Factory
             return results;
         }
 
-        private sealed record class AppInstall(
-            string Bucket,
-            string Architecture);
-        private sealed record class AppManifest(
-            string Homepage,
-            [property: JsonPropertyName("env_add_path"), JsonConverter(typeof(DynamicStringArrayConverter))]
-            string[] EnvAddPath,
-            [property: JsonConverter(typeof(DynamicStringArrayConverter))]
-            string[] Bin,
-            string[][] Shortcuts,
-            IDictionary<string, AppManifestArchitecture> Architecture);
-        private sealed record class AppManifestArchitecture(
-            [property: JsonPropertyName("env_add_path"), JsonConverter(typeof(DynamicStringArrayConverter))]
-            string[] EnvAddPath,
-            [property: JsonConverter(typeof(DynamicStringArrayConverter))]
-            string[] Bin,
-            string[][] Shortcuts);
+        private sealed class AppInstall
+        {
+            public string Bucket { get; set; }
+            public string Architecture { get; set; }
+        }
+        private sealed class AppManifest
+        {
+            public string Homepage { get; set; }
+            [JsonPropertyName("env_add_path"), JsonConverter(typeof(DynamicStringArrayConverter))]
+            public string[] EnvAddPath { get; set; }
+            [JsonConverter(typeof(DynamicStringArrayConverter))]
+            public string[] Bin { get; set; }
+            public string[][] Shortcuts { get; set; }
+            public IDictionary<string, AppManifestArchitecture> Architecture { get; set; }
+        }
+        private sealed class AppManifestArchitecture
+        {
+            public string[] EnvAddPath { get; set; }
+            [JsonConverter(typeof(DynamicStringArrayConverter))]
+            public string[] Bin { get; set; }
+            public string[][] Shortcuts { get; set; }
+        }
 
         public static ApplicationUninstallerEntry CreateUninstallerEntry(
             string name,

--- a/source/UninstallTools/Factory/ScoopFactory.cs
+++ b/source/UninstallTools/Factory/ScoopFactory.cs
@@ -179,13 +179,17 @@ namespace UninstallTools.Factory
 
         private record class AppManifest(
             string Homepage,
-            [property: JsonPropertyName("env_add_path"), JsonConverter(typeof(DynamicStringArrayConverter))] string[] EnvAddPath,
-            [property: JsonConverter(typeof(DynamicStringArrayConverter))] string[] Bin,
+            [property: JsonPropertyName("env_add_path"), JsonConverter(typeof(DynamicStringArrayConverter))]
+            string[] EnvAddPath,
+            [property: JsonConverter(typeof(DynamicStringArrayConverter))]
+            string[] Bin,
             string[][] Shortcuts,
             Dictionary<string, AppManifestArchitecture> Architecture);
         private record class AppManifestArchitecture(
-            [property: JsonPropertyName("env_add_path"), JsonConverter(typeof(DynamicStringArrayConverter))] string[] EnvAddPath,
-            [property: JsonConverter(typeof(DynamicStringArrayConverter))] string[] Bin,
+            [property: JsonPropertyName("env_add_path"), JsonConverter(typeof(DynamicStringArrayConverter))]
+            string[] EnvAddPath,
+            [property: JsonConverter(typeof(DynamicStringArrayConverter))]
+            string[] Bin,
             string[][] Shortcuts);
         private record class AppInstall(
             string Bucket,

--- a/source/UninstallTools/Factory/ScoopFactory.cs
+++ b/source/UninstallTools/Factory/ScoopFactory.cs
@@ -177,6 +177,9 @@ namespace UninstallTools.Factory
             return results;
         }
 
+        private sealed record class AppInstall(
+            string Bucket,
+            string Architecture);
         private sealed record class AppManifest(
             string Homepage,
             [property: JsonPropertyName("env_add_path"), JsonConverter(typeof(DynamicStringArrayConverter))]
@@ -191,9 +194,6 @@ namespace UninstallTools.Factory
             [property: JsonConverter(typeof(DynamicStringArrayConverter))]
             string[] Bin,
             string[][] Shortcuts);
-        private sealed record class AppInstall(
-            string Bucket,
-            string Architecture);
 
         public static ApplicationUninstallerEntry CreateUninstallerEntry(
             string name,

--- a/source/UninstallTools/Factory/ScoopFactory.cs
+++ b/source/UninstallTools/Factory/ScoopFactory.cs
@@ -1,25 +1,37 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using Klocman.Native;
 using Klocman.Tools;
 using UninstallTools.Factory.InfoAdders;
+using UninstallTools.Factory.Json;
 using UninstallTools.Junk.Confidence;
 using UninstallTools.Junk.Containers;
 using UninstallTools.Properties;
 
 namespace UninstallTools.Factory
 {
-    public sealed class ScoopFactory : IIndependantUninstallerFactory
+    public sealed partial class ScoopFactory : IIndependantUninstallerFactory
     {
         private static bool? _scoopIsAvailable;
         private static string _scoopUserPath;
         private static string _scoopGlobalPath;
         private static string _scriptPath;
         private static string _powershellPath;
+        private static readonly JsonContext _jsonContext;
+
+        static ScoopFactory()
+        {
+            JsonSerializerOptions jsonOptions = new(JsonSerializerDefaults.Web); // ignore property name case
+            jsonOptions.Converters.Add(new PowerShellDateTimeOffsetConverter());
+            _jsonContext = new JsonContext(jsonOptions);
+        }
 
         private static bool ScoopIsAvailable
         {
@@ -63,7 +75,24 @@ namespace UninstallTools.Factory
             }
         }
 
-        // TODO read the app manifests for more info, requires json parsing - var manifest = Path.Combine(installDir, "current\\manifest.json");
+        private record class ExportInfo(
+            //ExportBucketEntry[] Buckets,
+            ExportAppEntry[] Apps);
+        //private record class ExportBucketEntry(
+        //    string Name,
+        //    string Source,
+        //    DateTimeOffset Updated,
+        //    ulong Manifests);
+        private record class ExportAppEntry(
+            string Name,
+            string Version,
+            string Source,
+            DateTimeOffset Updated,
+            string Info)
+        {
+            [JsonIgnore] public bool IsPublic => Info?.Contains("Global install", StringComparison.InvariantCultureIgnoreCase) == true;
+        }
+
         public IList<ApplicationUninstallerEntry> GetUninstallerEntries(ListGenerationProgress.ListGenerationCallback progressCallback)
         {
             var results = new List<ApplicationUninstallerEntry>();
@@ -74,7 +103,7 @@ namespace UninstallTools.Factory
             {
                 RawDisplayName = "Scoop",
                 Comment = "Automated program installer",
-                AboutUrl = "https://github.com/lukesampson/scoop",
+                AboutUrl = "https://github.com/ScoopInstaller/Scoop",
                 InstallLocation = _scoopUserPath
             };
 
@@ -92,59 +121,161 @@ namespace UninstallTools.Factory
             var result = RunScoopCommand("export");
             if (string.IsNullOrEmpty(result)) return results;
 
-            var appEntries = result.Split(StringTools.NewLineChars.ToArray(), StringSplitOptions.RemoveEmptyEntries).Select(x => x.Trim());
             var exeSearcher = new AppExecutablesSearcher();
-            foreach (var str in appEntries)
+
+            // JSON export format since July 2022
+            try
             {
-                // Format should be "$app (v:$ver) $global_display $bucket $arch"
-                // app has no spaces, $global_display is *global*, bucket is inside [] brackets like [main]
-                // version should always be there but the check errored out for some users, everything after version is optional
-                string name;
-                string version = null;
-                bool isGlobal = false;
-                var spaceIndex = str.IndexOf(" ", StringComparison.Ordinal);
-                if (spaceIndex > 0)
+                var export = JsonSerializer.Deserialize(result, _jsonContext.ExportInfo);
+                foreach (var app in export.Apps)
                 {
-                    name = str.Substring(0, spaceIndex);
+                    var entry = CreateUninstallerEntry(
+                        app.Name, app.Version, app.IsPublic, exeSearcher);
 
-                    var startIndex = str.IndexOf("(v:", StringComparison.Ordinal);
-                    if (startIndex > 0)
+                    entry.InstallDate = app.Updated.LocalDateTime;
+
+                    results.Add(entry);
+                }
+            }
+            // Fallback to plain text export format
+            catch (JsonException)
+            {
+                var appEntries = result.Split(StringTools.NewLineChars.ToArray(), StringSplitOptions.RemoveEmptyEntries).Select(x => x.Trim());
+                foreach (var str in appEntries)
+                {
+                    // Format should be "$app (v:$ver) $global_display $bucket $arch"
+                    // app has no spaces, $global_display is *global*, bucket is inside [] brackets like [main]
+                    // version should always be there but the check errored out for some users, everything after version is optional
+                    string name;
+                    string version = null;
+                    bool isGlobal = false;
+                    var spaceIndex = str.IndexOf(" ", StringComparison.Ordinal);
+                    if (spaceIndex > 0)
                     {
-                        var verEndIndex = str.IndexOf(')', startIndex);
-                        version = str.Substring(Math.Min(startIndex + 3, str.Length - 1), Math.Max(verEndIndex - startIndex - 3, 0));
-                        if (version.Length == 0) version = null;
+                        name = str.Substring(0, spaceIndex);
+
+                        var startIndex = str.IndexOf("(v:", StringComparison.Ordinal);
+                        if (startIndex > 0)
+                        {
+                            var verEndIndex = str.IndexOf(')', startIndex);
+                            version = str.Substring(Math.Min(startIndex + 3, str.Length - 1), Math.Max(verEndIndex - startIndex - 3, 0));
+                            if (version.Length == 0) version = null;
+                        }
+                        isGlobal = str.Substring(spaceIndex).Contains("*global*");
                     }
-                    isGlobal = str.Substring(spaceIndex).Contains("*global*");
+                    else
+                    {
+                        name = str;
+                    }
+
+                    var entry = CreateUninstallerEntry(name, version, isGlobal, exeSearcher);
+
+                    results.Add(entry);
                 }
-                else
-                {
-                    name = str;
-                }
-
-                var entry = new ApplicationUninstallerEntry
-                {
-                    RawDisplayName = name,
-                    DisplayVersion = ApplicationEntryTools.CleanupDisplayVersion(version),
-                    RatingId = "Scoop " + name
-                };
-
-                var installDir = Path.Combine(isGlobal ? _scoopGlobalPath : _scoopUserPath, "apps\\" + name);
-                if (Directory.Exists(installDir))
-                {
-                    // Avoid looking for executables in old versions
-                    entry.InstallLocation = Path.Combine(installDir, "current");
-                    exeSearcher.AddMissingInformation(entry);
-
-                    entry.InstallLocation = installDir;
-                }
-
-                entry.UninstallerKind = UninstallerType.PowerShell;
-                entry.UninstallString = MakeScoopCommand("uninstall " + name + (isGlobal ? " --global" : "")).ToString();
-
-                results.Add(entry);
             }
 
             return results;
+        }
+
+        private record class AppManifest(
+            string Homepage,
+            [property: JsonPropertyName("env_add_path"), JsonConverter(typeof(DynamicStringArrayConverter))] string[] EnvAddPath,
+            [property: JsonConverter(typeof(DynamicStringArrayConverter))] string[] Bin,
+            string[][] Shortcuts,
+            Dictionary<string, AppManifestArchitecture> Architecture);
+        private record class AppManifestArchitecture(
+            [property: JsonPropertyName("env_add_path"), JsonConverter(typeof(DynamicStringArrayConverter))] string[] EnvAddPath,
+            [property: JsonConverter(typeof(DynamicStringArrayConverter))] string[] Bin,
+            string[][] Shortcuts);
+        private record class AppInstall(
+            string Bucket,
+            string Architecture);
+
+        public static ApplicationUninstallerEntry CreateUninstallerEntry(
+            string name,
+            string version,
+            bool isGlobal,
+            AppExecutablesSearcher searcher)
+        {
+            var entry = new ApplicationUninstallerEntry
+            {
+                RawDisplayName = name,
+                DisplayVersion = ApplicationEntryTools.CleanupDisplayVersion(version),
+                RatingId = "Scoop " + name
+            };
+
+            var installDir = Path.Combine(isGlobal ? _scoopGlobalPath : _scoopUserPath, "apps\\" + name);
+            if (Directory.Exists(installDir))
+            {
+                List<string> executables = new();
+                var currentDir = Path.Combine(installDir, "current");
+
+                try
+                {
+                    var install = JsonSerializer.Deserialize(
+                        File.ReadAllText(Path.Combine(currentDir, "install.json")),
+                        _jsonContext.AppInstall);
+
+                    var manifest = JsonSerializer.Deserialize(
+                        File.ReadAllText(Path.Combine(currentDir, "manifest.json")),
+                        _jsonContext.AppManifest);
+
+                    entry.AboutUrl = manifest.Homepage;
+
+                    var shortcuts = manifest.Architecture?[install.Architecture]?.Shortcuts ?? manifest.Shortcuts;
+                    if (shortcuts != null)
+                    {
+                        executables.AddRange(
+                            shortcuts.Select(x => Path.Combine(currentDir, x[0])));
+
+                        var icons = shortcuts
+                            .Where(x => x.Length >= 4 && x[3].EndsWith(".ico"))
+                            .Select(x => Path.Combine(currentDir, x[3]));
+                        if (icons.Any())
+                        {
+                            try
+                            {
+                                entry.IconBitmap = new Icon(icons.First());
+                            }
+                            catch { }
+                        }
+                    }
+
+                    var bin = manifest.Architecture?[install.Architecture]?.Bin ?? manifest.Bin;
+                    if (bin != null)
+                    {
+                        executables.AddRange(bin.Select(x => Path.Combine(installDir, "current", x)));
+                    }
+
+                    var env = manifest.Architecture?[install.Architecture]?.EnvAddPath ?? manifest.EnvAddPath;
+                    if (env != null)
+                    {
+                        currentDir = Path.Combine(currentDir, env[0]);
+                    }
+                }
+                catch (IOException)
+                { }
+                catch (UnauthorizedAccessException)
+                { }
+
+                if (executables.Any())
+                {
+                    entry.SortedExecutables = executables.Distinct().ToArray();
+                }
+                else
+                {
+                    // Avoid looking for executables in old versions
+                    entry.InstallLocation = currentDir;
+                    searcher.AddMissingInformation(entry);
+                }
+
+                entry.InstallLocation = installDir;
+            }
+
+            entry.UninstallerKind = UninstallerType.PowerShell;
+            entry.UninstallString = MakeScoopCommand("uninstall " + name + (isGlobal ? " --global" : "")).ToString();
+
+            return entry;
         }
 
         public bool IsEnabled() => UninstallToolsGlobalConfig.ScanScoop;
@@ -172,5 +303,12 @@ namespace UninstallTools.Factory
         {
             return new ProcessStartCommand(_powershellPath, $"-ex unrestricted \"{_scriptPath}\" {scoopArgs}");
         }
+
+
+        [JsonSerializable(typeof(ExportInfo))]
+        [JsonSerializable(typeof(AppInstall))]
+        [JsonSerializable(typeof(AppManifest))]
+        private partial class JsonContext : JsonSerializerContext
+        { }
     }
 }

--- a/source/UninstallTools/Factory/ScoopFactory.cs
+++ b/source/UninstallTools/Factory/ScoopFactory.cs
@@ -261,6 +261,8 @@ namespace UninstallTools.Factory
                 { }
                 catch (UnauthorizedAccessException)
                 { }
+                catch (JsonException)
+                { }
 
                 if (executables.Any())
                 {

--- a/source/UninstallTools/Factory/ScoopFactory.cs
+++ b/source/UninstallTools/Factory/ScoopFactory.cs
@@ -276,7 +276,11 @@ namespace UninstallTools.Factory
 
                 if (executables.Any())
                 {
-                    entry.SortedExecutables = executables.Distinct().ToArray();
+                    entry.SortedExecutables = AppExecutablesSearcher.SortListExecutables(
+                            executables.Distinct().Select(x => new FileInfo(x)),
+                            entry.DisplayNameTrimmed)
+                        .Select(x => x.FullName)
+                        .ToArray();
                 }
                 else
                 {

--- a/source/UninstallTools/Factory/ScoopFactory.cs
+++ b/source/UninstallTools/Factory/ScoopFactory.cs
@@ -75,15 +75,15 @@ namespace UninstallTools.Factory
             }
         }
 
-        private record class ExportInfo(
+        private sealed record class ExportInfo(
             //ExportBucketEntry[] Buckets,
             ExportAppEntry[] Apps);
-        //private record class ExportBucketEntry(
+        //private sealed record class ExportBucketEntry(
         //    string Name,
         //    string Source,
         //    DateTimeOffset Updated,
         //    ulong Manifests);
-        private record class ExportAppEntry(
+        private sealed record class ExportAppEntry(
             string Name,
             string Version,
             string Source,
@@ -177,7 +177,7 @@ namespace UninstallTools.Factory
             return results;
         }
 
-        private record class AppManifest(
+        private sealed record class AppManifest(
             string Homepage,
             [property: JsonPropertyName("env_add_path"), JsonConverter(typeof(DynamicStringArrayConverter))]
             string[] EnvAddPath,
@@ -185,13 +185,13 @@ namespace UninstallTools.Factory
             string[] Bin,
             string[][] Shortcuts,
             IDictionary<string, AppManifestArchitecture> Architecture);
-        private record class AppManifestArchitecture(
+        private sealed record class AppManifestArchitecture(
             [property: JsonPropertyName("env_add_path"), JsonConverter(typeof(DynamicStringArrayConverter))]
             string[] EnvAddPath,
             [property: JsonConverter(typeof(DynamicStringArrayConverter))]
             string[] Bin,
             string[][] Shortcuts);
-        private record class AppInstall(
+        private sealed record class AppInstall(
             string Bucket,
             string Architecture);
 
@@ -312,7 +312,7 @@ namespace UninstallTools.Factory
         [JsonSerializable(typeof(ExportInfo))]
         [JsonSerializable(typeof(AppInstall))]
         [JsonSerializable(typeof(AppManifest))]
-        private partial class JsonContext : JsonSerializerContext
+        private sealed partial class JsonContext : JsonSerializerContext
         { }
     }
 }

--- a/source/UninstallTools/Factory/ScoopFactory.cs
+++ b/source/UninstallTools/Factory/ScoopFactory.cs
@@ -184,7 +184,7 @@ namespace UninstallTools.Factory
             [property: JsonConverter(typeof(DynamicStringArrayConverter))]
             string[] Bin,
             string[][] Shortcuts,
-            Dictionary<string, AppManifestArchitecture> Architecture);
+            IDictionary<string, AppManifestArchitecture> Architecture);
         private record class AppManifestArchitecture(
             [property: JsonPropertyName("env_add_path"), JsonConverter(typeof(DynamicStringArrayConverter))]
             string[] EnvAddPath,


### PR DESCRIPTION
Closes #401 

---

- [x] Parse JSON export format
  - [x] Custom `DateTimeOffset` converter for Windows PowerShell compatibility
  - [x] Set `InstallDate` via `Updated`
  - [ ] ~~Set `InstallSource` via `Source`~~
  - [ ] ~~Set `RatingId` via `Source`~~
- [x] Parse app install and manifest JSON file
  - [x] Custom `string[]` converter for `bin` and `env_add_path`
  - [x] Set `AboutUrl` via `homepage`
  - [x] Set `SortedExecutables` via `shortcuts`, `bin`, and `env_add_path`
    - [x] `architecture` awareness
  - [x] Set `IconBitmap` via `shortcuts` with explicit ico file
- [x] `JsonSerializerContext` support for accelerating JSON parsing