### PR TITLE
More Dutch translation improvements.

### DIFF
--- a/source/BulkCrapUninstaller/Controls/Settings/CacheSettings.nl.resx
+++ b/source/BulkCrapUninstaller/Controls/Settings/CacheSettings.nl.resx
@@ -118,8 +118,8 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="label1.Text" xml:space="preserve">
-    <value>Caching kan zoektijden aanzienlijk reduceren, maar als een programma is gewijzigd, heeft BCU de wijziging(en) mogelijk niet opgemerkt, (bijv. de omvang).
-Opm: Voordat deze instellingen effect hebben, moet BCU mogelijk herstart worden.</value>
+    <value>Caching kan zoektijden aanzienlijk reduceren, maar als een programma is gewijzigd, heeft BCU de wijziging(en) mogelijk niet opgemerkt (bijv. de omvang).
+Opm.: voordat deze instellingen effect hebben, moet BCU mogelijk herstart worden.</value>
   </data>
   <data name="checkBoxCerts.Text" xml:space="preserve">
     <value>Cache programma certifcaat scan resultaten</value>

--- a/source/BulkCrapUninstaller/Controls/Settings/PropertiesSidebar.nl.resx
+++ b/source/BulkCrapUninstaller/Controls/Settings/PropertiesSidebar.nl.resx
@@ -124,7 +124,7 @@
     <value>Keuze met checkboxen</value>
   </data>
   <data name="checkBoxCertTest.ToolTip" xml:space="preserve">
-    <value>Kleuren gebruiken om gecertificeerde de-installer te identificeren. Succesvol gecontroleerde certificaten verschijnen in het groen, anders in blauw gekleurd.
+    <value>Kleuren gebruiken om gecertificeerde de-installer te identificeren. Succesvol gecontroleerde certificaten verschijnen in het groen, anders in het blauw gekleurd.
 Let op: De verificatie kan enige tijd duren.</value>
   </data>
   <data name="checkBoxShowUpdates.Text" xml:space="preserve">
@@ -145,16 +145,16 @@ U kunt meerdere onderdelen activeren, wanneer u deze markeert en op de spatiebal
     <value>Niet geregistreerde programma's tonen</value>
   </data>
   <data name="checkBoxListHideMicrosoft.ToolTip" xml:space="preserve">
-    <value>Alles verbergen wat door MIcrosoft werd uitgebracht.</value>
+    <value>Alles verbergen wat door Microsoft werd uitgebracht.</value>
   </data>
   <data name="checkBoxInvalidTest.ToolTip" xml:space="preserve">
-    <value>De kleur grijs kenmerkt beschadigde of ontbrekende uninstallers.</value>
+    <value>De grijze kleur betekende beschadigde of ontbrekende uninstallers.</value>
   </data>
   <data name="checkBoxViewGroups.Text" xml:space="preserve">
     <value>Toon onderdelen in groepen</value>
   </data>
   <data name="checkBoxListSysComp.ToolTip" xml:space="preserve">
-    <value>Enkele de-installers kunnen als 'systeem componenten zijn aangeduid, om deze te verbergen in de Toevoegen/Verwijderen software lijst.
+    <value>Enkele de-installers kunnen als systeem componenten zijn aangeduid, om deze te verbergen in de Toevoegen/Verwijderen software lijst.
 Stuurprogramma's zijn vaak gemarkeerd met dit label.</value>
   </data>
   <data name="groupBox1.Text" xml:space="preserve">
@@ -181,16 +181,16 @@ Stuurprogramma's zijn vaak gemarkeerd met dit label.</value>
   <data name="checkBoxOrphans.ToolTip" xml:space="preserve">
     <value>Weergave van programma's, die geen enkele gecertificeerde de-installer hebben. Deze blijven in de meeste de-installer programma's verborgen, maar nemen evenwel schijfruimte in. Niet geregistreerde onderdelen worden rood weergegeven.
 
-Waarschuwing: Controleer alvorens deze programma's te verwijderen of deze niet nodig zijn!</value>
+Waarschuwing: controleer alvorens deze programma's te verwijderen of deze niet nodig zijn!</value>
   </data>
   <data name="checkBoxShowStoreApps.Text" xml:space="preserve">
     <value>Windows Store apps tonen</value>
   </data>
   <data name="checkBoxWinFeature.Text" xml:space="preserve">
-    <value>Toon Windows onderdelen</value>
+    <value>Windows onderdelen tonen</value>
   </data>
   <data name="checkBoxTweaks.Text" xml:space="preserve">
-    <value>Tweakes tonen</value>
+    <value>Tweaks tonen</value>
   </data>
   <data name="checkBoxHighlightSpecial.Text" xml:space="preserve">
     <value>Markeer speciale de-installers </value>

--- a/source/BulkCrapUninstaller/Controls/Settings/PropertiesSidebar.nl.resx
+++ b/source/BulkCrapUninstaller/Controls/Settings/PropertiesSidebar.nl.resx
@@ -125,7 +125,7 @@
   </data>
   <data name="checkBoxCertTest.ToolTip" xml:space="preserve">
     <value>Kleuren gebruiken om gecertificeerde de-installer te identificeren. Succesvol gecontroleerde certificaten verschijnen in het groen, anders in het blauw gekleurd.
-Let op: De verificatie kan enige tijd duren.</value>
+Let op: de verificatie kan enige tijd duren.</value>
   </data>
   <data name="checkBoxShowUpdates.Text" xml:space="preserve">
     <value>Updates tonen</value>

--- a/source/BulkCrapUninstaller/Controls/Settings/UninstallationSettings.nl.resx
+++ b/source/BulkCrapUninstaller/Controls/Settings/UninstallationSettings.nl.resx
@@ -169,6 +169,6 @@
     <value>Maak een herstelpunt alvorens te de-installeren</value>
   </data>
   <data name="checkBoxRestorePoint.ToolTip" xml:space="preserve">
-    <value>U kunt een systeem herstelpunt maken voor een back-up van het register, sommige instellingen en bestanden. Het wordt aanbevolen om een herstelpunt te maken voor het verwijderen van stuurprogramma's en belangrijke systeem programma's.</value>
+    <value>Het is mogelijk om een systeem herstelpunt maken voor een back-up van het register, sommige instellingen en bestanden. Het wordt aanbevolen om een herstelpunt te maken voor het verwijderen van stuurprogramma's en belangrijke systeem programma's.</value>
   </data>
 </root>

--- a/source/BulkCrapUninstaller/Controls/UninstallConfirmation.nl.resx
+++ b/source/BulkCrapUninstaller/Controls/UninstallConfirmation.nl.resx
@@ -136,6 +136,6 @@
     <value>Dit is een lijst met programma's die zullen worden gede-installeerd, volgordelijk van boven naar beneden. Wanneer u het "De-installeer" veld deselecteerd, wordt het programma niet gede-installeerd. Als stille de-installatie niet beschikbaar is voor een onderdeel, kan dit niet worden aangevinkt.</value>
   </data>
   <data name="labelInfo2.Text" xml:space="preserve">
-    <value>De initiële volgorde hangt af van uw de-installatie instellingen, maar dit kan worden gewijzigd door de onderdelen te verslepen. Opm: BCU kan de volgorde wijzigen als gelijktijdige de-installatie is ingeschakeld.</value>
+    <value>De initiële volgorde hangt af van uw de-installatie instellingen, maar dit kan worden gewijzigd door de onderdelen te verslepen. Opm.: BCU kan de volgorde wijzigen als gelijktijdige de-installatie is ingeschakeld.</value>
   </data>
 </root>

--- a/source/BulkCrapUninstaller/Forms/Helpers/NewsPopup.nl.resx
+++ b/source/BulkCrapUninstaller/Forms/Helpers/NewsPopup.nl.resx
@@ -142,8 +142,7 @@
     <value>Doneer (PayPal, Bitcoin, Steam giften)</value>
   </data>
   <data name="label1.Text" xml:space="preserve">
-    <value>(Klik ergens om dit dialoogvenster te sluiten)
-</value>
+    <value>(Klik ergens om dit dialoogvenster te sluiten)</value>
   </data>
   <data name="checkBoxNeverShow.Text" xml:space="preserve">
     <value>Toon dit venster nooit meer</value>

--- a/source/BulkCrapUninstaller/Forms/Helpers/TargetWindow.nl.resx
+++ b/source/BulkCrapUninstaller/Forms/Helpers/TargetWindow.nl.resx
@@ -131,7 +131,7 @@
 </value>
   </data>
   <data name="label2.Text" xml:space="preserve">
-    <value>Opm: Overtuig u er van dat de door u geselecteerde bestanden zich bevinden in de installatie map.
+    <value>Opm.: overtuig u er van dat de door u geselecteerde bestanden zich bevinden in de installatie map.
 
 U kunt een map selecteren die meerdere programma's bevat om deze te de-installeren.</value>
   </data>

--- a/source/BulkCrapUninstaller/Forms/Windows/MainWindow.nl.resx
+++ b/source/BulkCrapUninstaller/Forms/Windows/MainWindow.nl.resx
@@ -178,7 +178,7 @@
     <value>Selecteer alles</value>
   </data>
   <data name="toolStripButtonSelNone.Text" xml:space="preserve">
-    <value>De-selecteer alles</value>
+    <value>Deselecteer alles</value>
   </data>
   <data name="toolStripButtonSelInv.Text" xml:space="preserve">
     <value>Omkeren selectie</value>
@@ -208,7 +208,7 @@
     <value>Zoeken</value>
   </data>
   <data name="uninstallContextMenuStripItem.Text" xml:space="preserve">
-    <value>&amp;De-ïnstalleer</value>
+    <value>&amp;De-installeer</value>
   </data>
   <data name="quietUninstallContextMenuStripItem.Text" xml:space="preserve">
     <value>&amp;De-installeer 'stil'</value>
@@ -247,7 +247,7 @@
     <value>Volledig register pad</value>
   </data>
   <data name="uninstallStringCopyContextMenuStripItem.Text" xml:space="preserve">
-    <value>Deïnstallatie string</value>
+    <value>De-installatie string</value>
   </data>
   <data name="copyToClipboardContextMenuStripItem.Text" xml:space="preserve">
     <value>&amp;Kopiëren naar klembord</value>
@@ -367,7 +367,7 @@
     <value>&amp;Installatie locatie</value>
   </data>
   <data name="toolStripMenuItem6.Text" xml:space="preserve">
-    <value>&amp;De-ïnstallatie locatie</value>
+    <value>&amp;De-installatie locatie</value>
   </data>
   <data name="toolStripMenuItem7.Text" xml:space="preserve">
     <value>&amp;Bron locatie</value>
@@ -403,7 +403,7 @@
     <value>&amp;Installeren of configureren (/l)</value>
   </data>
   <data name="toolStripMenuItem3.Text" xml:space="preserve">
-    <value>&amp;Deïnstalleren (/X)</value>
+    <value>&amp;De-installeren (/X)</value>
   </data>
   <data name="toolStripMenuItem4.Text" xml:space="preserve">
     <value>&amp;Stille de-installatie (/X /qb)</value>
@@ -430,13 +430,13 @@
     <value>&amp;Geavanceerde bewerkingen</value>
   </data>
   <data name="cleanUpProgramFilesToolStripMenuItem.Text" xml:space="preserve">
-    <value>&amp;Opruimen "Programma bestanden"mappen...</value>
+    <value>&amp;Opruimen "Programma bestanden" mappen...</value>
   </data>
   <data name="openStartupManagerToolStripMenuItem.Text" xml:space="preserve">
     <value>Opstartmanager openen</value>
   </data>
   <data name="uninstallFromDirectoryToolStripMenuItem.Text" xml:space="preserve">
-    <value>De-ïnstalleer uit de map...</value>
+    <value>De-installeer uit de map...</value>
   </data>
   <data name="settingsToolStripMenuItem.Text" xml:space="preserve">
     <value>&amp;Instellingen</value>
@@ -481,7 +481,7 @@
     <value>"&amp;Programma's en onderdelen" openen</value>
   </data>
   <data name="openSystemRestoreToolStripMenuItem.Text" xml:space="preserve">
-    <value>"Systeemherstel"  openen</value>
+    <value>"Systeemherstel" openen</value>
   </data>
   <data name="openHelpToolStripMenuItem.Text" xml:space="preserve">
     <value>&amp;Help openen</value>
@@ -520,14 +520,13 @@
     <value>Bekijk ongeregistreerd</value>
   </data>
   <data name="viewWindowsFeaturesToolStripMenuItem.Text" xml:space="preserve">
-    <value>Bekijk WIndows onderdelen</value>
+    <value>Bekijk Windows onderdelen</value>
   </data>
   <data name="toolStripButtonModify.Text" xml:space="preserve">
     <value>Wijzigen</value>
   </data>
   <data name="excludeToolStripMenuItem.Text" xml:space="preserve">
-    <value>Uitsluiten
-</value>
+    <value>Uitsluiten</value>
   </data>
   <data name="includeToolStripMenuItem.Text" xml:space="preserve">
     <value>Inbegrepen</value>
@@ -569,7 +568,7 @@
     <value>Foutopsporing de-installatie problemen</value>
   </data>
   <data name="startDiskCleanupToolStripMenuItem.Text" xml:space="preserve">
-    <value>Start  schijfopruiming</value>
+    <value>Start schijfopruiming</value>
   </data>
   <data name="tryToInstallNETV35ToolStripMenuItem.Text" xml:space="preserve">
     <value>Installeer .NET v3.5 (toevoeg functie)</value>

--- a/source/BulkCrapUninstaller/Forms/Windows/SettingsWindow.nl.resx
+++ b/source/BulkCrapUninstaller/Forms/Windows/SettingsWindow.nl.resx
@@ -142,7 +142,7 @@
     <value>Bericht vensters</value>
   </data>
   <data name="checkBoxShowAllBadJunk.Text" xml:space="preserve">
-    <value>Rommel die u niet vertrouwt altijd weergeven</value>
+    <value>Rommel dat u niet vertrouwt altijd weergeven</value>
   </data>
   <data name="checkBoxLoud.Text" xml:space="preserve">
     <value>Vragen, of normale de-installers uit de lijst met stille deïnstallers moet worden verwijderd</value>
@@ -163,7 +163,7 @@
     <value>Uitvoeren van externe programma's toestaan</value>
   </data>
   <data name="button2.Text" xml:space="preserve">
-    <value>S&amp;luiten</value>
+    <value>Sluiten</value>
   </data>
   <data name="tabPageGeneral.Text" xml:space="preserve">
     <value>Algemeen</value>
@@ -181,7 +181,7 @@
     <value>De detectie van Windows onderdelen gebruikt WMI en kan traag zijn of zelfs mislukken op sommige systemen (meestal een gevolg van systeem corruptie).</value>
   </data>
   <data name="checkBoxScanWinUpdates.Text" xml:space="preserve">
-    <value>Windows Update</value>
+    <value>Windows update</value>
   </data>
   <data name="labelWinUpdateInfo.Text" xml:space="preserve">
     <value>Detectie van Windows updates gebruikt WUA, wat traag verloopt. Dit kan enkele minuten duren tot voltooiïng.</value>
@@ -208,10 +208,10 @@
     <value>Bulk Crap Uninstaller instellingen</value>
   </data>
   <data name="label5.Text" xml:space="preserve">
-    <value>Opdrachtregel voordat de deïnstallatie start</value>
+    <value>Opdrachtregel voordat de de-installatie start</value>
   </data>
   <data name="label6.Text" xml:space="preserve">
-    <value>Opdrachtregel nadat de deïnstallatie is voltooid</value>
+    <value>Opdrachtregel nadat de de-installatie is voltooid</value>
   </data>
   <data name="label7.Text" xml:space="preserve">
     <value>U kunt opdrachten opgeven die voor en/of na de de-installatie worden uitgevoerd. Op elke regel één opdracht en deze wordt dan uitgevoerd als of u de dialoog "Uitvoeren..." zou gebruiken.
@@ -219,7 +219,7 @@
 BCU wacht tot de momenteel uitgevoerde opdracht is voltooïd, voordat de volgende wordt uitgevoerd.</value>
   </data>
   <data name="labelProgramFolders.Text" xml:space="preserve">
-    <value>U kunt aangepaste mappen opgeven, waarin u uw programma's heeft geïnstalleerd (bijv. D:\Programmas). Deze mappen worden door BCU gebruikt om te zoeken naar deïnstallatie van restanten, ongeregistreerde programma's en andere zaken.
+    <value>U kunt aangepaste mappen opgeven, waarin u uw programma's heeft geïnstalleerd (bijv. D:\Programmas). Deze mappen worden door BCU gebruikt om te zoeken naar de-installatie van restanten, ongeregistreerde programma's en andere zaken.
 Ofschoon niet noodzakelijk, laat een lijst met dergelijke mappen BCU beter functioneren.
 
 De standaard Windows mappen worden altijd gescand, deze hoeven niet opgenomen te worden in genoemde lijst.

--- a/source/BulkCrapUninstaller/Forms/Wizards/FirstStartBox.nl.resx
+++ b/source/BulkCrapUninstaller/Forms/Wizards/FirstStartBox.nl.resx
@@ -184,29 +184,29 @@ Controleer daarvoor de betreffende XML-bestanden in de BCUinstaller map.</value>
     <value>Automatisch anonieme gebruiks statistieken versturen</value>
   </data>
   <data name="p4netUsageAdd.Text" xml:space="preserve">
-    <value>Deze statistieken helpen mij BCUninstaller te verbeteren.</value>
+    <value>Deze statistieken helpen om BCUninstaller te verbeteren.</value>
   </data>
   <data name="checkBoxRatings.Text" xml:space="preserve">
-    <value>Inschakelen gebruikers waarderingen voor programma's.</value>
+    <value>Inschakelen gebruikers beoordelingen voor programma's.</value>
   </data>
   <data name="pCorTitle.Text" xml:space="preserve">
     <value>Beschadigde de-installer</value>
   </data>
   <data name="pCorDesc.Text" xml:space="preserve">
-    <value>Van tijd tot tijd kan het voorkomen, dat een programma weigert te de-installeren of eenvoudig weg uit de meeste  de-installer-programma's verdwijnt.</value>
+    <value>Van tijd tot tijd kan het voorkomen, dat een programma weigert te de-installeren of eenvoudig weg uit de meeste  de-installer programma's verdwijnt.</value>
   </data>
   <data name="pCorViewInvalidTitle.Text" xml:space="preserve">
     <value>Beschadigde of ontbrekende de-installer(s)</value>
   </data>
   <data name="pCorViewInvalid.Text" xml:space="preserve">
-    <value>In sommige gevallen kunnen uninstallers beschadigd zijn, zodat men niet kan de-installeren.
+    <value>In sommige gevallen kunnen de-installers beschadigd zijn, zodat men niet kan de-installeren.
 BCUninstaller kan deze registraties met de optie "Handmatig de-installeren" verwijderen.</value>
   </data>
   <data name="checkBoxInvalidTest.Text" xml:space="preserve">
-    <value>Beschadigde uninstallers accentueren</value>
+    <value>Beschadigde de-installers accentueren</value>
   </data>
   <data name="pCorViewinvalidComment.Text" xml:space="preserve">
-    <value>Beschadigde uninstallers worden grijs weergegeven</value>
+    <value>Beschadigde de-installers worden grijs weergegeven</value>
   </data>
   <data name="pCorOrphansTitle.Text" xml:space="preserve">
     <value>Niet geregistreerde toepassing</value>
@@ -231,7 +231,7 @@ Ontbreekt de originele de-installer, dan kunt u de optie "Handmatig de-instalere
     <value>Systeem componenten</value>
   </data>
   <data name="p3advSyscomp.Text" xml:space="preserve">
-    <value>Programma's die als 'systeem-component(en)' zijn aangeduid, worden door de meeste deïnstallers verborgen. Deze aanduiding betekent NIET, dat het programma tot het besturingssysteem behoort. </value>
+    <value>Programma's die als 'systeem component(en)' zijn aangeduid, worden door de meeste deïnstallers verborgen. Deze aanduiding betekent NIET, dat het programma tot het besturingssysteem behoort. </value>
   </data>
   <data name="checkBoxListSysComp.Text" xml:space="preserve">
     <value>Als 'systeem componenten' aangeduide de-installers tonen</value>

--- a/source/BulkCrapUninstaller/Properties/Localisable.nl.resx
+++ b/source/BulkCrapUninstaller/Properties/Localisable.nl.resx
@@ -204,13 +204,13 @@ Bestanden en mappen worden verplaatst naar de prullenbak, van waar uit u deze ku
     <comment>0 is the uninstaller count</comment>
   </data>
   <data name="MessageBoxes_Title_Rename_uninstaller" xml:space="preserve">
-    <value>Deïnstaller hernoemen</value>
+    <value>De-installer hernoemen</value>
   </data>
   <data name="MessageBoxes_InvalidNewEntryName_Message" xml:space="preserve">
     <value>De opgegeven naam is leeg of bevat ongeldige tekens</value>
   </data>
   <data name="MessageBoxes_LookForJunkQuestion_Details" xml:space="preserve">
-    <value>Let op: Dit onderdeel is alleen bedoeld voor ervaren gebruikers, die begrijpen hoe het eea. werkt. Het is niet nodig om deze bestanden te verwijderen, als deze de systeem prestaties niet wezenlijk beïnvloeden.</value>
+    <value>Let op: dit onderdeel is alleen bedoeld voor ervaren gebruikers, die begrijpen hoe het e.e.a. werkt. Het is niet nodig om deze bestanden te verwijderen, als deze de systeem prestaties niet wezenlijk beïnvloeden.</value>
   </data>
   <data name="MessageBoxes_NoJunkFoundInfo_Message" xml:space="preserve">
     <value>Geen programma restanten gevonden</value>
@@ -225,10 +225,10 @@ Bestanden en mappen worden verplaatst naar de prullenbak, van waar uit u deze ku
     <value>Niets om naar te zoeken</value>
   </data>
   <data name="MessageBoxes_SelfUninstallQuestion_Title" xml:space="preserve">
-    <value>BCUninstaller deïnstalleren</value>
+    <value>BCUninstaller de-installeren</value>
   </data>
   <data name="MessageBoxes_SelfUninstallQuestion_Message" xml:space="preserve">
-    <value>Wilt u BCUninstaller daadwerkelijk deïnstalleren?</value>
+    <value>Wilt u BCUninstaller daadwerkelijk de-installeren?</value>
   </data>
   <data name="MessageBoxes_SysRestoreBeginQuestion_Message" xml:space="preserve">
     <value>Wilt u een herstelpunt maken voordat u verder gaat?</value>
@@ -255,10 +255,10 @@ Bestanden en mappen worden verplaatst naar de prullenbak, van waar uit u deze ku
     <value>Bestand niet gevonden</value>
   </data>
   <data name="LoadingDialogTitlePostUninstallCommands" xml:space="preserve">
-    <value>Uitvoeren van NA-deïnstallatie opdrachten...</value>
+    <value>Uitvoeren van NA-de-installatie opdrachten...</value>
   </data>
   <data name="LoadingDialogTitlePreUninstallCommands" xml:space="preserve">
-    <value>Uitvoeren van VOOR-deïnstallatie opdrachten...</value>
+    <value>Uitvoeren van VOOR-de-installatie opdrachten...</value>
   </data>
   <data name="MainWindow_Statusbar_StatusReady" xml:space="preserve">
     <value>Voltooid</value>
@@ -326,7 +326,7 @@ The lists are separated by a single newline.</comment>
     <value>Dit programma heeft geen geldige register ingang</value>
   </data>
   <data name="PropertiesWindow_Table_ErrorMissingUninstaller" xml:space="preserve">
-    <value>Dit programma heeft geen geldige deïnstaller</value>
+    <value>Dit programma heeft geen geldige de-installer</value>
   </data>
   <data name="MainWindow_Statusbar_RefreshingStartup" xml:space="preserve">
     <value>Verversen opstart informatie...</value>
@@ -349,7 +349,7 @@ The lists are separated by a single newline.</comment>
     <value>U kunt onjuist geïnstalleerde programma's niet waarderen.</value>
   </data>
   <data name="RateTitle_Counted" xml:space="preserve">
-    <value>{0} Programma's</value>
+    <value>{0} programma's</value>
     <comment>{0} is number of apps to rate, "Rate " will be automatically put in front of this string</comment>
   </data>
   <data name="MessageBoxes_ForceRunUninstallFailedError_Title" xml:space="preserve">
@@ -365,7 +365,7 @@ The lists are separated by a single newline.</comment>
     <value>.NET Framework v4.0 werd niet gevonden, enkele functies zullen worden uitgeschakeld</value>
   </data>
   <data name="MessageBoxes_Net4Missing_Details" xml:space="preserve">
-    <value>Het v4.0 Framework is optioneel, maar wordt aanbevolen. De functies die zijn gebaseerd op dit Framework, zullen worden uitgeschakeld tot dat u dit installeert.</value>
+    <value>Het v4.0 Framework is optioneel, maar wordt aanbevolen. De functies die zijn gebaseerd op dit framework, zullen worden uitgeschakeld tot dat u dit installeert.</value>
   </data>
   <data name="MessageBoxes_AskToRetryFailedQuietAsLoud_Title" xml:space="preserve">
     <value>Enkele de-installers mislukten</value>
@@ -389,13 +389,13 @@ The lists are separated by a single newline.</comment>
     <value>Er werden geen programma's gevonden in de opgegeven map</value>
   </data>
   <data name="MessageBoxes_UninstallFromDirectoryNothingFound_Details" xml:space="preserve">
-    <value>Overtuig u zelf dat u de juiste map selecteerde en dat de uitvoerbare programma's (.exe) nog aanwezig zijn.</value>
+    <value>Controleer dat u de juiste map selecteerde en dat de uitvoerbare programma's (.exe) nog aanwezig zijn.</value>
   </data>
   <data name="MessageBoxes_UninstallFromDirectoryUninstallerFound_Message" xml:space="preserve">
-    <value>Een uninstaller gevonden voor {0}</value>
+    <value>Een de-installer gevonden voor {0}</value>
   </data>
   <data name="MessageBoxes_UninstallFromDirectoryUninstallerFound_Details" xml:space="preserve">
-    <value>Wilt u deze uninstaller uitvoeren?</value>
+    <value>Wilt u deze de-installer uitvoeren?</value>
   </data>
   <data name="LocalizedX509Certificate2_Issuer" xml:space="preserve">
     <value>Verlener</value>
@@ -422,7 +422,7 @@ The lists are separated by a single newline.</comment>
     <value>Niet voor</value>
   </data>
   <data name="LocalizedX509Certificate2_PrivateKey" xml:space="preserve">
-    <value>Prive sleutel</value>
+    <value>Privé sleutel</value>
   </data>
   <data name="LocalizedX509Certificate2_HasPrivateKey" xml:space="preserve">
     <value>Heeft een prive sleutel</value>
@@ -461,7 +461,7 @@ The lists are separated by a single newline.</comment>
     <value>Gemiddelde waardering: {0}; Mijn waardering: {1}</value>
   </data>
   <data name="MessageBoxes_NoNetworkConnected_Details" xml:space="preserve">
-    <value>Controleer dat de netwerkkabel is aangesloten. Gebruikt u Wi-Fi overtuig u dan van een goede signaalsterkte.</value>
+    <value>Controleer dat de netwerkkabel is aangesloten. Indien u gebruik maakt van Wi-Fi, controleer dan de signaalsterke.</value>
   </data>
   <data name="MessageBoxes_Title_Submit_feedback" xml:space="preserve">
     <value>Feedback sturen</value>
@@ -480,13 +480,13 @@ U kunt dit ook later sturen via de hoofd menubalk (Help -&gt; Feedback sturen).<
   <data name="MessageBoxes_UpdateUptodate_Details" xml:space="preserve">
     <value>Er werden geen updates gevonden, u heeft de laatste versie.
 
-Mist u functionaliteiten of wilt u een oplossing voor een fout? Stuur mij dan uw feedback via het menu "Help -&gt; Feedback sturen).</value>
+Mist u functionaliteiten of wilt u een oplossing voor een fout? Stuur mij dan uw feedback via het menu (Help -&gt; Feedback sturen).</value>
   </data>
   <data name="MessageBoxes_UpdateFailed_Message" xml:space="preserve">
     <value>Er werd een fout ontdekt bij het zoeken naar updates!</value>
   </data>
   <data name="MessageBoxes_UpdateFailed_Details" xml:space="preserve">
-    <value>Overtuig u ervan dat BCUninstaller niet wordt geblokkeerd door uw 'firewall' en dat u een werkende Internet verbinding heeft.</value>
+    <value>Controleer dat BCUninstaller niet wordt geblokkeerd door uw 'firewall' en dat u een werkende internet verbinding hebt.</value>
   </data>
   <data name="MessageBoxes_UpdateAskToDownload_Message" xml:space="preserve">
     <value>Een nieuwe versie {0} is beschikbaar, wilt u nu upgraden?</value>
@@ -496,7 +496,7 @@ Mist u functionaliteiten of wilt u een oplossing voor een fout? Stuur mij dan uw
     <value>De geselecteerde registratie kan niet met de MsiEx-Installer worden gede-installeerd.</value>
   </data>
   <data name="MessageBoxes_UninstallMsiGuidMissing_Details" xml:space="preserve">
-    <value>De geselecteerde uninstaller heeft geen geldige Guid voor het gebruik met MsiExec.</value>
+    <value>De geselecteerde de-installer heeft geen geldige Guid voor het gebruik met MsiExec.</value>
   </data>
   <data name="MessageBoxes_TaskStopConfirmation_Title" xml:space="preserve">
     <value>De actuele de-installatie taak beëindigen?</value>
@@ -504,7 +504,7 @@ Mist u functionaliteiten of wilt u een oplossing voor een fout? Stuur mij dan uw
   <data name="MessageBoxes_TaskSkip_Details" xml:space="preserve">
     <value>De keuze 'Beëindigen" sluit onmiddellijk de lopende de-installer en kan er in resulteren dat de de-installatie niet wordt afgesloten. In de regel kunt u de de-installer opnieuw uitvoeren om de de-installatie af te sluiten.
 
-Als alternatief kunt u de wachttijd voor dit proces overslaan. Hierdoor werkt de deïnstaller door, terwijl de taak naar het volgende onderdeel springt.
+Als alternatief kunt u de wachttijd voor dit proces overslaan. Hierdoor werkt de de-installer door, terwijl de taak naar het volgende onderdeel springt.
 Denk er aan, dat enkele deïnstallers niet kunnen worden uitgevoerd, voor dat het overgeslagen proces is afgesloten.</value>
   </data>
   <data name="JunkRemove_Details_Title" xml:space="preserve">
@@ -525,18 +525,18 @@ U kunt proberen de detectie van conflicten in de instellingen uit te schakelen, 
 Wijzigingen log:
 - {0}
 
-Waarschuwing: Tijdens de update worden de map "Update" en het bestand "Update.zip" in de BCU mappen verwijderd.</value>
+Waarschuwing: tijdens de update worden de map "Update" en het bestand "Update.zip" in de BCU mappen verwijderd.</value>
     <comment>0 is a list of changes separated by "- "</comment>
   </data>
   <data name="MessageBoxes_SysRestoreContinueAfterError_Message" xml:space="preserve">
     <value>Kon geen nieuw herstelpunt maken</value>
   </data>
   <data name="Str64Bit" xml:space="preserve">
-    <value>x64</value>
+    <value> x64</value>
     <comment>keep space in front</comment>
   </data>
   <data name="StrDebug" xml:space="preserve">
-    <value>DEBUG</value>
+    <value> DEBUG</value>
     <comment>keep space in front</comment>
   </data>
   <data name="MessageBoxes_CanWalkAwayInfo_Title" xml:space="preserve">
@@ -546,8 +546,8 @@ Waarschuwing: Tijdens de update worden de map "Update" en het bestand "Update.zi
     <value>U kunt de computer nu uitzetten.</value>
   </data>
   <data name="MessageBoxes_CanWalkAwayInfo_Details" xml:space="preserve">
-    <value>Resterende uninstallers zouden zonder gebruikers interventie moeten voltooiïen.
-Van tijd tot tijd zou u moeten of een van de uninstallers niet is gecrashed.</value>
+    <value>Resterende de-installers zouden zonder gebruikers interventie moeten voltooiïen.
+Van tijd tot tijd zou u moeten of een van de de-installers niet is gecrashed.</value>
   </data>
   <data name="MessageBoxes_Title_Junk_Leftover_removal" xml:space="preserve">
     <value>Afval/Programma restanten verwijderen</value>
@@ -565,7 +565,7 @@ Van tijd tot tijd zou u moeten of een van de uninstallers niet is gecrashed.</va
     <value>Weet u zekere dat u de geselecteerde de-installer registraties wilt verwijderen?</value>
   </data>
   <data name="MessageBoxes_DeleteRegKeysConfirmation_Details" xml:space="preserve">
-    <value>De volgende onderdelen werden uit het register verwijderd en verdwijnen uit de deïnstaller lijst, maar worden niet gede-installeerd.
+    <value>De volgende onderdelen werden uit het register verwijderd en verdwijnen uit de de-installer lijst, maar worden niet gede-installeerd.
 
 {0}</value>
   </data>
@@ -594,8 +594,7 @@ Van tijd tot tijd zou u moeten of een van de uninstallers niet is gecrashed.</va
   </data>
   <data name="MessageBoxes_OpenDirectoriesMessageBox_OpenMultiple" xml:space="preserve">
     <value>Deze bewerking opent {0} mappen tegelijk. Weet u zeker dat u verder wilt gaan?</value>
-    <comment>0 is number of directories to open
-</comment>
+    <comment>0 is number of directories to open</comment>
   </data>
   <data name="MessageBoxes_Title_Quiet_uninstall" xml:space="preserve">
     <value>Stille de-installatie</value>
@@ -610,7 +609,7 @@ Van tijd tot tijd zou u moeten of een van de uninstallers niet is gecrashed.</va
     <value>De-installatie lijst openen</value>
   </data>
   <data name="MessageBoxes_SysRestoreContinueAfterError_Details" xml:space="preserve">
-    <value>Het herstelpunt WERD NIET GEMAAKT, u kunt wijzigingen niet herstellen! Wilt u toch doorgaan met de deïnstallatie?</value>
+    <value>Het herstelpunt WERD NIET GEMAAKT, u kunt wijzigingen niet herstellen! Wilt u toch doorgaan met de de-installatie?</value>
   </data>
   <data name="MainWindow_Rename_Description" xml:space="preserve">
     <value>Hernoemen "{0}"</value>
@@ -636,7 +635,7 @@ Van tijd tot tijd zou u moeten of een van de uninstallers niet is gecrashed.</va
     <value>Het bestand bestaat niet</value>
   </data>
   <data name="PropertiesWindow_Table_ErrorMsi" xml:space="preserve">
-    <value>Niets om weer te geven. Dit programmma wordt mbv. de Windows Installer (MsiExec) gede-installeerd.</value>
+    <value>Niets om weer te geven. Dit programmma wordt m.b.v. de Windows Installer (MsiExec) gede-installeerd.</value>
   </data>
   <data name="MessageBoxes_SelfUninstallQuestion_Details" xml:space="preserve">
     <value>Jammer dat u ons gaat verlaten! Als u enkele minuten heeft, laat mij dan met een kort bericht op mijn website (http://klocmansoftware.weebly.com/) weten waarom u BCU deïnstalleerde. Ik zal mijn best doen om gemelde problemen op te lossen.</value>
@@ -675,11 +674,10 @@ Van tijd tot tijd zou u moeten of een van de uninstallers niet is gecrashed.</va
     <value>De geselecteerde bestanden konden niet worden geladen</value>
   </data>
   <data name="MessageBoxes_NoUninstallersSelectedInfo_Message" xml:space="preserve">
-    <value>Geen uninstaller geselecteerd, er is niets om te de-installeren
-</value>
+    <value>Geen uninstaller geselecteerd, er is niets om te de-installeren</value>
   </data>
   <data name="MessageBoxes_NoUninstallersSelectedInfo_Title" xml:space="preserve">
-    <value>Uninstaller uitvoeren</value>
+    <value>De-installer uitvoeren</value>
   </data>
   <data name="MessageBoxes_Title_Open_urls" xml:space="preserve">
     <value>URL's openen</value>
@@ -695,17 +693,17 @@ Van tijd tot tijd zou u moeten of een van de uninstallers niet is gecrashed.</va
   </data>
   <data name="MessageBoxes_TaskStopConfirmation_Details" xml:space="preserve">
     <value>Het voortijdig beëindigen van de taak maakt, dat terugzetten niet mogelijk is.
-De lopende uninstaller wordt niet gestopt, deze taak wacht op zijn voltooiïng.</value>
+De lopende de-installer wordt niet gestopt, deze taak wacht op zijn voltooiïng.</value>
   </data>
   <data name="MessageBoxes_SysRestoreBeginQuestion_Details" xml:space="preserve">
-    <value>Bent u onzeker of de programma's die u wilt deïnstalleren, belangrijk of voor de systeemstabiliteit vereist zijn? Dan wordt aanbevolen om een herstelpunt te maken.
+    <value>Bent u onzeker of de programma's die u wilt de-installeren, belangrijk of voor de systeemstabiliteit vereist zijn? Dan wordt aanbevolen om een herstelpunt te maken.
 Mocht er onverhoopt iets mis gaan, dan kunt u met systeemherstel de wijziging(en) ongedaan maken.</value>
   </data>
   <data name="MessageBoxes_NoUninstallersSelectedInfo_Details" xml:space="preserve">
     <value>Om programma's te de-installeren moet u deze eerst in de getoonde lijst selecteren. Als u gebruik maakt van checkboxen, controleer dan dat deze aangevinkt zijn.</value>
   </data>
   <data name="MessageBoxes_OpenUninstallListQuestion_Details" xml:space="preserve">
-    <value>Als u de huidige selectie wilt bewaren, wordt deze met de geopende lijst(en) samengevoegd.</value>
+    <value>Als u de huidige selectie wilt opslaan, wordt deze met de geopende lijst(en) samengevoegd.</value>
   </data>
   <data name="MessageBoxes_OpenUrlsMessageBox_OpenMultiple_Message" xml:space="preserve">
     <value>Deze bewerking opent {0} URL's. Weet u zeker dat u wilt doorgaan?</value>
@@ -715,14 +713,14 @@ Mocht er onverhoopt iets mis gaan, dan kunt u met systeemherstel de wijziging(en
 Getroffen registraties:
 {0}
 
-Om deze registraties te wijzigen, moet u uit de instellingen in de zijbalk lijst de beveiliging van de uninstaller uitschakelen. U kunt deze uit de taak verwijderen en met de andere onderdelen doorgaan.</value>
+Om deze registraties te wijzigen, moet u uit de instellingen in de zijbalk lijst de beveiliging van de de-installer uitschakelen. U kunt deze uit de taak verwijderen en met de andere onderdelen doorgaan.</value>
     <comment>0 names of protected uninstallers</comment>
   </data>
   <data name="MessageBoxes_ProtectedItemError_Details" xml:space="preserve">
     <value>
 Beveilgde registratie: {0}
 
-Om deze registratie te wijzigen, moet u de beveiliging van de deïnstaller in het instellingen venster uitschakelen.</value>
+Om deze registratie te wijzigen, moet u de beveiliging van de de-installer in het instellingen venster uitschakelen.</value>
     <comment>0 name of protected uninstaller</comment>
   </data>
   <data name="MessageBoxes_QuietUninstallersNotAvailableQuestion_Details" xml:space="preserve">
@@ -730,7 +728,7 @@ Om deze registratie te wijzigen, moet u de beveiliging van de deïnstaller in he
 De volgende onderdelen hebben geen onzichtbare de-installer(s):
 {0}
 
-Wilt u voor deze onderdelen de standaard uninstaller gebruiken of moeten de registraties uit de taak worden verwijderd?</value>
+Wilt u voor deze onderdelen de standaard de-installer gebruiken of moeten de registraties uit de taak worden verwijderd?</value>
     <comment>0 is names of non-quiet uninstallers</comment>
   </data>
   <data name="TargetWindow_NoFilesSelected_Title" xml:space="preserve">
@@ -771,7 +769,7 @@ Het kan noodzakelijk zijn om te de-installeren en het dan opnieuw te installeren
     <value>Selecteer waar de back-up opgeslagen moet worden. Een nieuwe map zal worden gemaakt.</value>
   </data>
   <data name="NewsPopup_UpdatedTitle" xml:space="preserve">
-    <value>BCU is geüpdated naar v{0}!</value>
+    <value>BCU is geüpdatet naar v{0}!</value>
   </data>
   <data name="NewsPopup_FirstStartTitle" xml:space="preserve">
     <value>Welkom bij BCU versie {0}!</value>

--- a/source/BulkCrapUninstaller/Properties/Localisable.nl.resx
+++ b/source/BulkCrapUninstaller/Properties/Localisable.nl.resx
@@ -140,7 +140,7 @@
 Uitgever | Versie | Datum | Grootte | Registry | De-installatie type | De-installatie string | De-installatie string (stil) | Commentaar</value>
   </data>
   <data name="StrIsPortable" xml:space="preserve">
-    <value>Portabel</value>
+    <value> Portabel</value>
     <comment>keep space in front</comment>
   </data>
   <data name="SysRestoreGenericError" xml:space="preserve">

--- a/source/KlocTools/Forms/ProcessWaiterControl.nl.resx
+++ b/source/KlocTools/Forms/ProcessWaiterControl.nl.resx
@@ -131,6 +131,6 @@
   </data>
   <data name="label1.Text" xml:space="preserve">
     <value>De volgende processen gebruiken mogelijk bestanden, die nu gedeïnstalleerd moeten worden.
-Sluit deze eerst voordat u verder gaat. Als u ervoor kiest deze niet te sluiten, kan de deïnstallatie mislukken of problemen veroorzaken. Daardoor verliest u ook alle niet opgeslagen gegevens, die door deze toepasssing(en) geopend zijn.</value>
+Sluit deze eerst voordat u verder gaat. Als u ervoor kiest deze niet te sluiten, kan de de-installatie mislukken of problemen veroorzaken. Daardoor verliest u ook alle niet opgeslagen gegevens, die door deze toepasssing(en) geopend zijn.</value>
   </data>
 </root>

--- a/source/NBug_custom/Properties/Localization.nl.resx
+++ b/source/NBug_custom/Properties/Localization.nl.resx
@@ -138,11 +138,11 @@
     <comment>General</comment>
   </data>
   <data name="UI_Dialog_Full_How_to_Reproduce_the_Error_Notification" xml:space="preserve">
-    <value>Beschrijf hier a.u.b., hoe de fout gereproduceerd kan worden:</value>
+    <value>Gelieve hier de fout te beschrijven en hoe de fout gereproduceerd kan worden:</value>
     <comment>Please add a brief description of how we can reproduce the error:</comment>
   </data>
   <data name="UI_Dialog_Full_Message" xml:space="preserve">
-    <value>Het programma is gecrashed en wordt nu beëindigd. Als u op "Afsluiten" klikt, wordt het programma meteen gesloten. Indien u op " Versturen en afsluiten"  klikt, wordt vervolgens een foutenbericht naar de ontwikkelaar gestuurd en wordt het programma aansluitend afgesloten. </value>
+    <value>Het programma is gecrashed en wordt nu beëindigd. Als u op "Afsluiten" klikt, wordt het programma meteen gesloten. Indien u op "Versturen en afsluiten"  klikt, wordt vervolgens een foutenbericht naar de ontwikkelaar gestuurd en wordt het programma aansluitend afgesloten. </value>
     <comment>The application has crashed and it will now be dismissed. If you click Quit, the application will close immediately. If you click Send and Quit, the application will close and a bug report will be send.</comment>
   </data>
   <data name="UI_Dialog_Full_Quit_Button" xml:space="preserve">
@@ -175,7 +175,7 @@ A bug report has been sent to the developers. We apologize for the inconvenience
     <comment>&amp;Continue</comment>
   </data>
   <data name="UI_Dialog_Normal_Message" xml:space="preserve">
-    <value>Er trad een onbehandelde uitzondering op. Als u op " Doorgaan" klikt wordt de fout genegeerd en probeert het programma te vervolgen. Als u op " Afsluiten"  klikt, wordt het programma onmiddellijk gesloten. </value>
+    <value>Er trad een onbehandelde uitzondering op. Als u op " Doorgaan" klikt wordt de fout genegeerd en probeert het programma te vervolgen. Als u op "Afsluiten"  klikt, wordt het programma onmiddellijk gesloten. </value>
     <comment>.</comment>
   </data>
   <data name="UI_Dialog_Normal_Quit_Button" xml:space="preserve">

--- a/source/UninstallTools/Dialogs/StartupManagerWindow.nl.resx
+++ b/source/UninstallTools/Dialogs/StartupManagerWindow.nl.resx
@@ -157,7 +157,7 @@
     <value>Opdracht</value>
   </data>
   <data name="openFileLocationToolStripMenuItem.Text" xml:space="preserve">
-    <value>EXE-opslag locatie o&amp;penen</value>
+    <value>EXE-opslag locatie openen</value>
   </data>
   <data name="openLinkLocationToolStripMenuItem.Text" xml:space="preserve">
     <value>Link opslag locatie openen</value>

--- a/source/UninstallerAutomatizer/Forms/MainWindow.nl.resx
+++ b/source/UninstallerAutomatizer/Forms/MainWindow.nl.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="label1.Text" xml:space="preserve">
-    <value>Deze tool de-installeert automatisch programma's die geen 'stille' installer hebben, door te klikken op de knoppen van de uninstaller in plaats van door de gebruiker.</value>
+    <value>Deze tool de-installeert automatisch programma's die geen 'stille' installer hebben, door te klikken op de knoppen van de de-installer in plaats van door de gebruiker.</value>
   </data>
   <data name="groupBox1.Text" xml:space="preserve">
     <value>Status</value>

--- a/source/UninstallerAutomatizer/Forms/MainWindow.nl.resx
+++ b/source/UninstallerAutomatizer/Forms/MainWindow.nl.resx
@@ -133,7 +133,7 @@
     <value>Afbreken</value>
   </data>
   <data name="$this.Text" xml:space="preserve">
-    <value>Uninstaller automatisering</value>
+    <value>De-installer automatisering</value>
   </data>
   <data name="checkBoxUninstallerVisible.Text" xml:space="preserve">
     <value>De-installer zichtbaar</value>

--- a/source/UniversalUninstaller/Properties/Localisation.nl.resx
+++ b/source/UniversalUninstaller/Properties/Localisation.nl.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Program_ShowInvalidArgsBox_Message" xml:space="preserve">
-    <value>Ongeldig aantal argumenten. Geef het volledige pad op van de te verwijderen map als een argumenten en optioneel /q voor 'stille' modus.</value>
+    <value>Ongeldig aantal argumenten. Geef het volledige pad op van de te verwijderen map als een argument en optioneel /q voor 'stille' modus.</value>
   </data>
   <data name="Program_ShowInvalidArgsBox_Title" xml:space="preserve">
     <value>Universele de-installer</value>


### PR DESCRIPTION
In this commit, I added a lot of improvements. Here are some highlights:

* Changed some translations where "Check if you are online" was translated literally to "Ensure yourself you are online".
* Some accents were removed where they weren't needed.
* Double spaces and such removed.
* Improved consistency over the app in the translation.