### PR TITLE
Small typo in Portuguese version of RelatedUninstallerAdder

### DIFF
--- a/source/BulkCrapUninstaller/Controls/RelatedUninstallerAdder.pt.resx
+++ b/source/BulkCrapUninstaller/Controls/RelatedUninstallerAdder.pt.resx
@@ -127,7 +127,7 @@
     <value>Relacionado com:</value>
   </data>
   <data name="labelInfo.Text" xml:space="preserve">
-    <value>Esta é a lista de aplicativos que podem estar relacionados com os aplicativos que selecionou para desinstalar. Pode adicionaá-los à lista de desinstalação, procedendo à sua verificação.</value>
+    <value>Esta é a lista de aplicativos que podem estar relacionados com os aplicativos que selecionou para desinstalar. Pode adicioná-los à lista de desinstalação, procedendo à sua verificação.</value>
   </data>
   <data name="labelInfo2.Text" xml:space="preserve">
     <value>Certifique-se de que não desinstala software importante que ainda é necessário para que outras aplicações funcionem correctamente.</value>


### PR DESCRIPTION
Line 130 in `RelatedUninstallerAdder.pt.resx` had an extra `a` in `adicioná-los`.

Since this is `PT`, Portuguese from Portugal, I didn't change the `correctamente` at line 133. Just saying.