### PR TITLE
Vietnamese translation fix

### DIFF
--- a/source/BulkCrapUninstaller/Controls/FileTargeter.vi.resx
+++ b/source/BulkCrapUninstaller/Controls/FileTargeter.vi.resx
@@ -127,6 +127,6 @@
     <value>Tất cả tệp|*.*</value>
   </data>
   <data name="button1.Text" xml:space="preserve">
-    <value>Liên kết hoặc tập tin cho ứng dụng...</value>
+    <value>Đường dẫn hoặc tệp tin ứng dụng...</value>
   </data>
 </root>

--- a/source/BulkCrapUninstaller/Controls/ListLegend.vi.resx
+++ b/source/BulkCrapUninstaller/Controls/ListLegend.vi.resx
@@ -118,10 +118,10 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="labelWinFeature.Text" xml:space="preserve">
-    <value>Tình năng của Windows</value>
+    <value>Windows Feature</value>
   </data>
   <data name="labelOrphaned.Text" xml:space="preserve">
-    <value>Ứng dụng chưa được đăng ký</value>
+    <value>Ứng dụng chưa đăng ký</value>
   </data>
   <data name="labelInvalid.Text" xml:space="preserve">
     <value>Thiếu trình gỡ cài đặt</value>
@@ -136,6 +136,6 @@
     <value>Chú thích màu</value>
   </data>
   <data name="labelStoreApp.Text" xml:space="preserve">
-    <value>Windows Store App</value>
+    <value>Ứng dụng từ Windows Store</value>
   </data>
 </root>

--- a/source/BulkCrapUninstaller/Controls/RelatedUninstallerAdder.vi.resx
+++ b/source/BulkCrapUninstaller/Controls/RelatedUninstallerAdder.vi.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="olvColumnName.Text" xml:space="preserve">
-    <value>Tên trình gỡ cài đặt liên quan</value>
+    <value>Tên trình gỡ cài có đặt liên quan</value>
   </data>
   <data name="olvColumnEnabled.Text" xml:space="preserve">
     <value>Thêm vào danh sách tác vụ</value>
@@ -127,9 +127,9 @@
     <value>Liên quan đến: </value>
   </data>
   <data name="labelInfo.Text" xml:space="preserve">
-    <value>Đây là danh sách các ứng dụng có thể liên quan đến ứng dụng bạn đã chọn để gỡ cài đặt. Bằng cách kiểm tra các ứng dụng này, bạn có thể thêm chúng vào hàng đợi gỡ cài đặt.</value>
+    <value>Đây là danh sách các ứng dụng có thể liên quan đến ứng các dụng bạn đã chọn để gỡ cài đặt. Bằng cách kiểm tra các ứng dụng này, bạn có thể thêm chúng vào hàng đợi gỡ cài đặt.</value>
   </data>
   <data name="labelInfo2.Text" xml:space="preserve">
-    <value>Hãy cẩn thận để không gỡ cài đặt phần mềm quan trọng mà các ứng dụng khác yêu cầu để hoạt động bình thường.</value>
+    <value>Hãy cẩn thận để không gỡ cài đặt phần mềm quan trọng mà các ứng dụng khác có thể cần để hoạt động bình thường.</value>
   </data>
 </root>

--- a/source/BulkCrapUninstaller/Controls/Settings/AdvancedFilters.vi.resx
+++ b/source/BulkCrapUninstaller/Controls/Settings/AdvancedFilters.vi.resx
@@ -130,21 +130,21 @@
     <value>Lưu thành...</value>
   </data>
   <data name="toolStripButtonSaveUlDef.Text" xml:space="preserve">
-    <value>Lưu mặc định</value>
+    <value>Lưu làm mặc định</value>
   </data>
   <data name="toolStripButtonDelete.Text" xml:space="preserve">
-    <value>Xoá mặc định</value>
+    <value>Xoá danh sách mặc định</value>
   </data>
   <data name="saveUlDialog.Filter" xml:space="preserve">
-    <value>Danh sách gỡ cài đặt|*.bcul</value>
+    <value>Danh sách bộ lọc gỡ cài đặt|*.bcul</value>
   </data>
   <data name="saveUlDialog.Title" xml:space="preserve">
-    <value>Lưu Danh sách Gỡ cài đặt...</value>
+    <value>Lưu danh sách bộ lọc gỡ cài đặt...</value>
   </data>
   <data name="openUlDialog.Filter" xml:space="preserve">
-    <value>Danh sách gỡ cài đặt|*.bcul</value>
+    <value>Danh sách bộ lọc gỡ cài đặt|*.bcul</value>
   </data>
   <data name="openUlDialog.Title" xml:space="preserve">
-    <value>Mở Danh sách Gỡ cài đặt...</value>
+    <value>Mở danh sách bộ lọc gỡ cài đặt...</value>
   </data>
 </root>

--- a/source/BulkCrapUninstaller/Controls/Settings/CacheSettings.vi.resx
+++ b/source/BulkCrapUninstaller/Controls/Settings/CacheSettings.vi.resx
@@ -122,10 +122,10 @@
 Lưu ý: Bạn có thể cần phải khởi động lại BCU để các cài đặt này có hiệu lực.</value>
   </data>
   <data name="checkBoxCerts.Text" xml:space="preserve">
-    <value>Kết quả quét chứng chỉ của ứng dụng lưu trong bộ nhớ đệm</value>
+    <value>Lưu trữ tạm thời các kết quả quét chứng chỉ ứng dụng</value>
   </data>
   <data name="checkBoxInfo.Text" xml:space="preserve">
-    <value>Bộ nhớ đệm đã thu thập được thông tin bị thiếu</value>
+    <value>Lưu trữ tạm thời thông tin bị thiếu được thu thập</value>
   </data>
   <data name="button1.Text" xml:space="preserve">
     <value>Xoá bộ nhớ đệm</value>

--- a/source/BulkCrapUninstaller/Controls/Settings/PropertiesSidebar.vi.resx
+++ b/source/BulkCrapUninstaller/Controls/Settings/PropertiesSidebar.vi.resx
@@ -121,84 +121,84 @@
     <value>Hiển thị các ứng dụng chưa đăng ký</value>
   </data>
   <data name="checkBoxOrphans.ToolTip" xml:space="preserve">
-    <value>Hiển thị các ứng dụng chưa được đăng ký trình gỡ cài đặt. Chúng không hiển thị trong hầu hết các trình quản lý gỡ cài đặt nhưng vẫn chiếm dung lượng. Các mục chưa đăng ký được đánh dấu bằng màu đỏ.
+    <value>Hiển thị các ứng dụng chưa có bất kỳ trình gỡ cài đặt được đăng ký nào. Chúng không hiển thị trong hầu hết các trình quản lý gỡ cài đặt nhưng vẫn chiếm dung lượng. Các mục chưa đăng ký được đánh dấu bằng màu đỏ.
 
 Cảnh báo: Hãy kiểm tra kỹ trước khi xóa các ứng dụng này, chúng có thể vẫn cần thiết!</value>
   </data>
   <data name="checkBoxInvalidTest.Text" xml:space="preserve">
-    <value>Đánh dấu các trình gỡ cài đặt bị thiếu</value>
+    <value>Đánh dấu các mục thiếu trình gỡ cài đặt</value>
   </data>
   <data name="checkBoxInvalidTest.ToolTip" xml:space="preserve">
-    <value>Sử dụng màu xám để xác định trình gỡ cài đặt bị hỏng hoặc bị thiếu.</value>
+    <value>Dùng màu xám để xác định trình gỡ cài đặt bị hỏng hoặc bị thiếu.</value>
   </data>
   <data name="checkBoxCertTest.Text" xml:space="preserve">
-    <value>Đánh dấu trình gỡ cài đặt được chứng nhận</value>
+    <value>Đánh dấu trình gỡ cài đặt đã đạt chứng chỉ</value>
   </data>
   <data name="checkBoxCertTest.ToolTip" xml:space="preserve">
-    <value>Sử dụng màu sắc để xác định trình gỡ cài đặt được chứng nhận.
-Nếu chứng chỉ đã được xác minh thành công, hãy sử dụng màu xanh lá cây, nếu không hãy sử dụng màu xanh lam.
+    <value>Sử dụng màu sắc để xác định trình gỡ cài đặt đã đạt chứng chỉ.
+Màu xanh lục nếu chứng chỉ đã được xác minh thành công, ngược lại là màu xanh lam.
 
 Cảnh báo: Quá trình xác minh có thể mất nhiều thời gian để hoàn tất.</value>
   </data>
   <data name="checkBoxListHideMicrosoft.Text" xml:space="preserve">
-    <value>Ẩn do Microsoft xuất bản</value>
+    <value>Ẩn mọi thứ do Microsoft phát hành</value>
   </data>
   <data name="checkBoxListHideMicrosoft.ToolTip" xml:space="preserve">
-    <value>Lọc mọi thứ do Microsoft xuất bản. Đơn giản mà.</value>
+    <value>Lọc bỏ mọi thứ do Microsoft phát hành. Chỉ thế thôi.</value>
   </data>
   <data name="checkBoxListSysComp.Text" xml:space="preserve">
     <value>Hiển thị các thành phần hệ thống</value>
   </data>
   <data name="checkBoxListSysComp.ToolTip" xml:space="preserve">
-    <value>Một số trình gỡ cài đặt có thể được đánh dấu là "thành phần hệ thống" và bị ẩn khỏi danh sách Thêm/Xóa Phần mềm.
-Trình điều khiển thường được đánh dấu bằng thẻ này.</value>
+    <value>Một số trình gỡ cài đặt có thể được đánh dấu là "thành phần hệ thống" và bị ẩn khỏi danh sách Thêm/Xóa phần mềm.
+Các "Driver" thường được đánh dấu bằng thẻ này.</value>
   </data>
   <data name="checkBoxListProtected.Text" xml:space="preserve">
     <value>Hiển thị các mục được bảo vệ</value>
   </data>
   <data name="checkBoxListProtected.ToolTip" xml:space="preserve">
-    <value>Các mục được bảo vệ có thẻ "NoRemove", có nghĩa là nhà xuất bản không muốn xóa chúng.</value>
+    <value>Các mục được bảo vệ được đánh dấu bằng thẻ "NoRemove", có nghĩa là nhà phát hành không muốn bạn xóa chúng.</value>
   </data>
   <data name="checkBoxTweaks.Text" xml:space="preserve">
     <value>Hiển thị các tinh chỉnh</value>
   </data>
   <data name="checkBoxShowUpdates.Text" xml:space="preserve">
-    <value>Hiển thị cập nhật</value>
+    <value>Hiển thị các ứng dụng cập nhật</value>
   </data>
   <data name="checkBoxShowUpdates.ToolTip" xml:space="preserve">
-    <value>Cập nhật các ứng dụng khác. Thông thường, chúng được gỡ cài đặt cùng với ứng dụng gốc nên có thể bỏ qua.</value>
+    <value>Các ứng dụng dùng để cập nhật các ứng dụng khác. Chúng thường được gỡ cài đặt cùng với ứng dụng gốc nên có thể yên tâm bỏ qua.</value>
   </data>
   <data name="checkBoxWinFeature.Text" xml:space="preserve">
     <value>Hiển thị Windows features</value>
   </data>
   <data name="checkBoxShowStoreApps.Text" xml:space="preserve">
-    <value>Hiển thị Windows Store App</value>
+    <value>Hiển thị ứng dụng từ Windows Store</value>
   </data>
   <data name="groupBox2.Text" xml:space="preserve">
     <value>Bộ lọc</value>
   </data>
   <data name="checkBoxViewCheckboxes.Text" xml:space="preserve">
-    <value>Chọn bằng cách sử dụng hộp kiểm</value>
+    <value>Chọn bằng cách tích vào hộp kiểm</value>
   </data>
   <data name="checkBoxViewCheckboxes.ToolTip" xml:space="preserve">
-    <value>Thay đổi kiểu lựa chọn của danh sách thành các hộp kiểm. Chúng an toàn hơn vì một cú nhấp chuột không thể bỏ chọn mọi thứ.
+    <value>Thay đổi kiểu lựa chọn của danh sách thành bằng cách tích các hộp kiểm. Chúng an toàn hơn vì không thể bỏ chọn mọi thứ bằng một cú nhấp chuột.
 
-Bạn có thể kiểm tra nhiều mục bằng cách đánh dấu chúng và nhấn phím cách.</value>
+Bạn có thể kiểm tra nhiều mục bằng cách tích chúng và nhấn phím cách.</value>
   </data>
   <data name="checkBoxViewGroups.Text" xml:space="preserve">
     <value>Hiển thị các mục theo nhóm</value>
   </data>
   <data name="checkBoxViewGroups.ToolTip" xml:space="preserve">
     <value>Nhóm các mục trong danh sách theo các cột được sắp xếp.
-Hầu hết các nhóm cột đều sử dụng tính năng lọc thông minh.</value>
+Việc nhóm hầu hết các cột sử dụng bộ lọc thông minh.</value>
   </data>
   <data name="checkBoxHighlightSpecial.Text" xml:space="preserve">
     <value>Đánh dấu các trình gỡ cài đặt đặc biệt</value>
   </data>
   <data name="checkBoxHighlightSpecial.ToolTip" xml:space="preserve">
-    <value>Sử dụng màu sắc để phân biệt các ứng dụng đặc biệt, ví dụ như Store Apps và Windows Features.</value>
+    <value>Dùng màu sắc để phân biệt các ứng dụng đặc biệt, ví dụ như Store Apps và Windows Features.</value>
   </data>
   <data name="groupBox1.Text" xml:space="preserve">
-    <value>Cài đặt chế độ xem danh sách</value>
+    <value>Cài đặt chế độ xem</value>
   </data>
 </root>

--- a/source/BulkCrapUninstaller/Controls/Settings/UninstallationSettings.vi.resx
+++ b/source/BulkCrapUninstaller/Controls/Settings/UninstallationSettings.vi.resx
@@ -118,16 +118,17 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="checkBoxManualNoCollisionProtection.Text" xml:space="preserve">
-    <value>Tắt tính năng chống xung đột khi chạy trình gỡ cài đặt theo cách thủ công</value>
+    <value>Tắt tính năng chống xung đột khi chạy trình gỡ
+cài đặt theo cách thủ công</value>
   </data>
   <data name="checkBoxConcurrentOneLoud.Text" xml:space="preserve">
-    <value>Mỗi lần chỉ có thể chạy một trình gỡ cài đặt "ồn ào"</value>
+    <value>Mỗi lần chỉ chạy một trình gỡ cài đặt</value>
   </data>
   <data name="checkBoxConcurrent.Text" xml:space="preserve">
     <value>Tự động chạy đồng thời các trình gỡ cài đặt (nếu có thể)</value>
   </data>
   <data name="label2.Text" xml:space="preserve">
-    <value>Số lượng tối da trình gỡ cài đặt thực thi: </value>
+    <value>Số trình gỡ cài đặt tối đa chạy đồng thời:</value>
   </data>
   <data name="groupBox3.Text" xml:space="preserve">
     <value>Gỡ cài đặt đồng thời</value>
@@ -139,10 +140,10 @@
     <value>Tạo điểm khôi phục trước khi gỡ cài đặt</value>
   </data>
   <data name="checkBoxRestorePoint.ToolTip" xml:space="preserve">
-    <value>Bạn có thể sao lưu thanh ghi, một số cài đặt và tệp bằng cách tạo điểm khôi phục hệ thống. Bạn nên tạo điểm khôi phục trước khi xóa trình điều khiển và các ứng dụng hệ thống quan trọng.</value>
+    <value>Bạn có thể sao lưu registry, một số cài đặt và tệp bằng cách tạo điểm khôi phục hệ thống. Bạn nên tạo điểm khôi phục trước khi xóa driver và các ứng dụng hệ thống quan trọng.</value>
   </data>
   <data name="checkBoxBatchSortQuiet.Text" xml:space="preserve">
-    <value>Phân loại trình gỡ cài đặt một cách thông minh</value>
+    <value>Sắp xếp trình gỡ cài đặt một cách thông minh</value>
   </data>
   <data name="checkBoxDiisableProtection.Text" xml:space="preserve">
     <value>Vô hiệu hóa bảo vệ</value>
@@ -154,7 +155,7 @@
     <value>Cài đặt chung</value>
   </data>
   <data name="checkBoxAutoKillQuiet.Text" xml:space="preserve">
-    <value>Tự động kết thúc các trình gỡ cài đặt "âm thầm" bị kẹt</value>
+    <value>Tự động huỷ các trình gỡ cài đặt âm thầm bị lỗi</value>
   </data>
   <data name="checkBoxRetryQuiet.Text" xml:space="preserve">
     <value>Thử lại các trình gỡ cài đặt âm thầm không thành công một lần nữa</value>
@@ -163,10 +164,12 @@
     <value>Tạo trình gỡ cài đặt âm thầm bị thiếu nếu có thể</value>
   </data>
   <data name="checkBoxGenerateStuck.Text" xml:space="preserve">
-    <value>Tự động kết thúc một chương trình nếu nó bị kẹt trong quá trình chờ đợi người dùng nhập liệu</value>
+    <value>Tự động huỷ trình gỡ cài đặt nếu nó bị kẹt khi chờ thao tác của người dùng</value>
   </data>
   <data name="checkBoxAutoDaemon.Text" xml:space="preserve">
-    <value>Giám sát các trình gỡ cài đặt "âm thầm" để tìm cửa sổ bật lên hoặc các sự cố khác và tự động hóa chúng (chạy chương trình tự động chạy nền)</value>
+    <value>Giám sát các trình gỡ cài đặt "im lặng" bật lên cửa sổ
+không mong muốn hoặc treo máy, và tự động hóa chúng
+(chạy trình nền tự động)</value>
   </data>
   <data name="groupBox1.Text" xml:space="preserve">
     <value>Gỡ cài đặt âm thầm</value>

--- a/source/BulkCrapUninstaller/Controls/UninstallConfirmation.vi.resx
+++ b/source/BulkCrapUninstaller/Controls/UninstallConfirmation.vi.resx
@@ -118,10 +118,10 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="labelInfo2.Text" xml:space="preserve">
-    <value>Thứ tự ban đầu tùy thuộc vào tuỳ chọn gỡ cài đặt của bạn nhưng có thể thay đổi bằng cách kéo các mục. Lưu ý: BCU có thể thay đổi thứ tự nếu bật tính năng gỡ cài đặt đồng thời.</value>
+    <value>Thứ tự sắp xếp ban đầu tùy thuộc vào tuỳ chọn gỡ cài đặt của bạn nhưng có thể thay đổi bằng cách kéo các mục. Lưu ý: BCU có thể thay đổi thứ tự nếu bật tính năng gỡ cài đặt đồng thời.</value>
   </data>
   <data name="labelInfo.Text" xml:space="preserve">
-    <value>Đây là danh sách các ứng dụng sẽ được gỡ cài đặt, theo thứ tự từ trên xuống dưới. Nếu bạn bỏ chọn trường "Gỡ cài đặt", ứng dụng sẽ không được gỡ cài đặt. Nếu tính năng "Gỡ cài đặt âm thầm" không có sẵn cho một mục thì không thể kiểm tra mục đó.</value>
+    <value>Đây là danh sách các ứng dụng sẽ được gỡ cài đặt, theo thứ tự từ trên xuống dưới. Nếu bạn bỏ tích trường "Gỡ cài đặt", ứng dụng sẽ không được gỡ cài đặt. Nếu tính năng "Gỡ cài đặt âm thầm" không khả dụng cho một ứng dụng thì bạn không thể tích vào trường này.</value>
     <comment>jp translator: I don't know the difference between Quiet Uninstall and Silent Uninstall. Can I translate them to mean the same meaning? At this stage, we are trying to separate the two, but Quiet Uninstall is not very familiar to Japanese people.</comment>
   </data>
   <data name="buttonSmartSort.Text" xml:space="preserve">
@@ -131,7 +131,7 @@
     <value>Vị trí cài đặt</value>
   </data>
   <data name="olvColumnQuiet.Text" xml:space="preserve">
-    <value>Âm thầm</value>
+    <value>Gỡ cài đặt âm thầm</value>
   </data>
   <data name="olvColumnEnabled.Text" xml:space="preserve">
     <value>Gỡ cài đặt</value>

--- a/source/BulkCrapUninstaller/Forms/Helpers/FeedbackBox.vi.resx
+++ b/source/BulkCrapUninstaller/Forms/Helpers/FeedbackBox.vi.resx
@@ -121,7 +121,7 @@
     <value>Cảm ơn bạn đã sử dụng BCUninstaller!</value>
   </data>
   <data name="p1welcomeSubheading.Text" xml:space="preserve">
-    <value>Nếu bạn thấy công cụ nguồn mở miễn phí này hữu ích, hãy giúp chúng tôi! Hãy kể cho bạn bè của bạn, chia sẻ trên mạng xã hội, đưa ra phản hồi - ngay cả những điều nhỏ nhặt cũng có giá trị lâu dài!</value>
+    <value>Bạn đã thấy công cụ mã nguồn mở miễn phí này hữu ích chứ? Nếu có, hãy dành một phút để giúp chúng tôi nhé! Hãy giới thiệu nó với bạn bè của bạn, chia sẻ nó lên mạng xã hội, hay cung cấp phản hồi - mọi đóng góp nhỏ đều có giá trị!</value>
   </data>
   <data name="buttonSendFeedback2.Text" xml:space="preserve">
     <value>Gửi phản hồi</value>
@@ -133,22 +133,22 @@
     <value>Chia sẻ lên Twitter</value>
   </data>
   <data name="p1FeedbackHeading.Text" xml:space="preserve">
-    <value>Có bất kỳ vấn đề hoặc tính năng nào bị thiếu không?</value>
+    <value>Có bất kỳ trục trặc gì hay thiếu tính năng nào không?</value>
   </data>
   <data name="p1FeedbackDesc.Text" xml:space="preserve">
-    <value>Nếu bạn gặp bất kỳ vấn đề nào với BCU hoặc nếu bạn muốn đề xuất một tính năng mới, vui lòng kiểm tra các liên kết sau: </value>
+    <value>Nếu bạn gặp phải bất kỳ sự cố nào với BCU hoặc muốn đề xuất tính năng mới, vui lòng kiểm tra các liên kết này:</value>
   </data>
   <data name="buttonSubmitGithub.Text" xml:space="preserve">
-    <value>Gửi trên GitHub (Cần có tài khoản)</value>
+    <value>Gửi lên GitHub (Cần có tài khoản)</value>
   </data>
   <data name="buttonSendFeedback.Text" xml:space="preserve">
     <value>Gửi phản hồi</value>
   </data>
   <data name="p1HelpHeading.Text" xml:space="preserve">
-    <value>Bạn có muốn giúp đỡ không?</value>
+    <value>Bạn có muốn góp sức không?</value>
   </data>
   <data name="p1HelpDesc.Text" xml:space="preserve">
-    <value>Bạn không cần phải là một lập trình viên mới có thể trợ giúp! Bạn có thể quyên góp để tăng tốc độ cập nhật hoặc dịch BCU sang ngôn ngữ mẹ đẻ của bạn. Mọi sự giúp đỡ dù nhỏ đến đâu đều được đánh giá cao!</value>
+    <value>Bạn không cần phải là lập trình viên để góp sức! Bạn có thể quyên góp để đẩy nhanh quá trình cập nhật hoặc dịch BCU sang tiếng mẹ đẻ của bạn. Mọi sự giúp đỡ đều được trân trọng, dù là nhỏ nhất!</value>
   </data>
   <data name="buttonTranslate.Text" xml:space="preserve">
     <value>Dịch BCU</value>

--- a/source/BulkCrapUninstaller/Forms/Helpers/NewsPopup.vi.resx
+++ b/source/BulkCrapUninstaller/Forms/Helpers/NewsPopup.vi.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="label3.Text" xml:space="preserve">
-    <value>Các khoản quyên góp giúp tôi luôn quan tâm đến dự án này, cũng như trả tiền cho chứng chỉ ký mã, lưu trữ và các chi phí cần thiết khác.</value>
+    <value>Các khoản tài trợ giúp tôi duy trì sự hứng thú với dự án này, đồng thời cũng để thanh toán chi phí cho chứng chỉ ký code, lưu trữ và các nhu cầu cần thiết khác.</value>
   </data>
   <data name="linkLabel1.Text" xml:space="preserve">
     <value>Xem các bản ghi chú phát hành và nhật ký thay đổi</value>
@@ -133,7 +133,7 @@
     <value>Đọc chính sách bảo mật</value>
   </data>
   <data name="linkLabel5.Text" xml:space="preserve">
-    <value>Đọc tập tin trợ giúp</value>
+    <value>Đọc tệp tin trợ giúp</value>
   </data>
   <data name="linkLabel6.Text" xml:space="preserve">
     <value>Gửi phản hồi / Liên hệ với nhà phát triển</value>
@@ -142,7 +142,7 @@
     <value>Quyên góp (PayPal, Bitcoin, Steam gifts)</value>
   </data>
   <data name="label1.Text" xml:space="preserve">
-    <value>(Nhấp vào bất cứ đâu để đóng hộp thoại này)</value>
+    <value>(Nhấp chuột vào bất cứ đâu để đóng hộp thoại này)</value>
   </data>
   <data name="checkBoxNeverShow.Text" xml:space="preserve">
     <value>Không bao giờ hiển thị lại cửa sổ này nữa</value>

--- a/source/BulkCrapUninstaller/Forms/Helpers/PropertiesWindow.vi.resx
+++ b/source/BulkCrapUninstaller/Forms/Helpers/PropertiesWindow.vi.resx
@@ -137,12 +137,12 @@
     <value>Thông tin trình gỡ cài đặt</value>
   </data>
   <data name="tabPageRegistry.Text" xml:space="preserve">
-    <value>Thanh ghi</value>
+    <value>Registry</value>
   </data>
   <data name="tabPageCertificate.Text" xml:space="preserve">
     <value>Giấy chứng chỉ</value>
   </data>
   <data name="$this.Text" xml:space="preserve">
-    <value>Thuộc tính</value>
+    <value>Thông tin chi tiết </value>
   </data>
 </root>

--- a/source/BulkCrapUninstaller/Forms/Helpers/TargetWindow.vi.resx
+++ b/source/BulkCrapUninstaller/Forms/Helpers/TargetWindow.vi.resx
@@ -118,20 +118,20 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="groupBox1.Text" xml:space="preserve">
-    <value>Tìm bằng cách chọn một cửa sổ</value>
+    <value>Chọn một cửa sổ</value>
   </data>
   <data name="groupBox2.Text" xml:space="preserve">
-    <value>Tìm bằng cách chọn thư mục cài đặt hoặc tập tin ứng dụng</value>
+    <value>Chọn thư mục cài đặt hoặc tệp tin ứng dụng</value>
   </data>
   <data name="label1.Text" xml:space="preserve">
-    <value>Tìm và gỡ cài đặt ứng dụng dựa trên một trong các cửa sổ, lối tắt hoặc vị trí cài đặt hoặc tệp .exe của ứng dụng đó.</value>
+    <value>Tìm và gỡ cài đặt một ứng dụng dựa vào một trong các thông tin sau: cửa sổ, lối tắt hoặc vị trí cài đặt hoặc tệp .exe của ứng dụng đó.</value>
   </data>
   <data name="label2.Text" xml:space="preserve">
-    <value>Lưu ý: Đảm bảo tệp bạn chọn nằm trong thư mục bạn đã cài đặt ứng dụng.
+    <value>Lưu ý: Hãy đảm bảo bất kỳ tệp bạn chọn phải nằm trong thư mục cài đặt ứng dụng.
 
-Bạn có thể chọn một thư mục chứa nhiều ứng dụng để gỡ cài đặt tất cả chúng.</value>
+Bạn có thể chọn một thư mục chứa nhiều ứng dụng để gỡ cài đặt tất cả chúng cùng một lúc.</value>
   </data>
   <data name="$this.Text" xml:space="preserve">
-    <value>Ứng dụng mục tiêu</value>
+    <value>Nhắm mục tiêu ứng dụng</value>
   </data>
 </root>

--- a/source/BulkCrapUninstaller/Forms/Windows/AboutBox.vi.resx
+++ b/source/BulkCrapUninstaller/Forms/Windows/AboutBox.vi.resx
@@ -172,7 +172,7 @@
     <comment>I have translated it directly in Japanese, but it may not convey the meaning very well.</comment>
   </data>
   <data name="groupBox2.Text" xml:space="preserve">
-    <value>Tài nguyên được sử dụng</value>
+    <value>Thành phần được sử dụng</value>
   </data>
   <data name="button1.Text" xml:space="preserve">
     <value>Đóng</value>
@@ -187,6 +187,6 @@
     <value>Các dịch giả</value>
   </data>
   <data name="$this.Text" xml:space="preserve">
-    <value>Về BCUninstaller (Bulk Crap Uninstaller)</value>
+    <value>Giới thiệu về BCUninstaller (Bulk Crap Uninstaller)</value>
   </data>
 </root>

--- a/source/BulkCrapUninstaller/Forms/Windows/JunkRemoveWindow.vi.resx
+++ b/source/BulkCrapUninstaller/Forms/Windows/JunkRemoveWindow.vi.resx
@@ -127,28 +127,28 @@
     <value>&amp;Mở</value>
   </data>
   <data name="$this.Text" xml:space="preserve">
-    <value>Loại bỏ phần còn sót lại</value>
+    <value>Dọn dẹp những thứ còn sót lại</value>
   </data>
   <data name="groupBox1.Text" xml:space="preserve">
-    <value>Danh sách các tập tin và/hoặc mục thanh ghi còn lại sau khi gỡ cài đặt</value>
+    <value>Danh sách các tệp tin và/hoặc mã registry còn lại sau khi gỡ cài đặt</value>
   </data>
   <data name="headerConfInfo.Text" xml:space="preserve">
-    <value>Việc phát hiện những phần còn sót lại này là một quá trình phức tạp và có thể xảy ra sai sót. Do đó, tất cả các mục đều được xếp hạng độ tin cậy và quyết định cuối cùng thuộc về người dùng. Những mục có độ tin cậy tốt và rất tốt thường có thể tháo ra một cách an toàn, nhưng bạn vẫn nên kiểm tra lại chúng.</value>
+    <value>Việc phát hiện những mục dư thừa này là một quá trình phức tạp và có thể mắc sai sót. Do đó, tất cả các mục đều được đánh giá mức độ tin cậy và quyết định cuối cùng thuộc về bạn. Những mục có mức độ tin cậy tốt và rất tốt thường an toàn để xóa, nhưng bạn vẫn nên kiểm tra lại chúng.</value>
   </data>
   <data name="headerConfTitle.Text" xml:space="preserve">
     <value>Mức độ tin cậy</value>
   </data>
   <data name="headerIntro.Text" xml:space="preserve">
-    <value>Các mục sau đây dường như bị trình gỡ cài đặt của chúng bỏ lại. Một số trình gỡ cài đặt có thể không xóa được một số mục, điều này có thể chiếm dung lượng ổ đĩa. Tuy nhiên, hầu hết các mục này có thể là cài đặt ứng dụng, không chiếm dung lượng và vô hại.</value>
+    <value>Các mục sau đây dường như bị trình gỡ cài đặt của chúng bỏ lại. Một số trình gỡ cài đặt có thể không xóa được một số mục, và có thể dẫn đến chiếm dung lượng ổ đĩa. Tuy nhiên, hầu hết các mục này có thể là cài đặt của ứng dụng, thường chiếm rất ít dung lượng và vô hại.</value>
   </data>
   <data name="olvColumnUninstallerName.Text" xml:space="preserve">
-    <value>Tên Trình gỡ cài đặt</value>
+    <value>Tên trình gỡ cài đặt</value>
   </data>
   <data name="olvColumnSafety.Text" xml:space="preserve">
     <value>Độ tin cậy</value>
   </data>
   <data name="olvColumnPath.Text" xml:space="preserve">
-    <value>Đường dẫn mục</value>
+    <value>Đường dẫn</value>
   </data>
   <data name="checkBoxHideLowConfidence.Text" xml:space="preserve">
     <value>Ẩn các mục có độ tin cậy thấp</value>

--- a/source/BulkCrapUninstaller/Forms/Windows/MainWindow.vi.resx
+++ b/source/BulkCrapUninstaller/Forms/Windows/MainWindow.vi.resx
@@ -121,7 +121,7 @@
     <value>Tên</value>
   </data>
   <data name="olvColumnPublisher.Text" xml:space="preserve">
-    <value>Nhà xuất bản</value>
+    <value>Nhà phát hành</value>
   </data>
   <data name="olvColumnRating.Text" xml:space="preserve">
     <value>Đánh giá của người dùng</value>
@@ -136,7 +136,7 @@
     <value>Kích thước</value>
   </data>
   <data name="olvColumnStartup.Text" xml:space="preserve">
-    <value>Đang khởi động</value>
+    <value>Khởi động cùng hệ thống</value>
   </data>
   <data name="olvColumnIs64.Text" xml:space="preserve">
     <value>64bit</value>
@@ -145,7 +145,7 @@
     <value>Câu lệnh gỡ cài đặt</value>
   </data>
   <data name="olvColumnAbout.Text" xml:space="preserve">
-    <value>URL</value>
+    <value>URL giới thiệu</value>
   </data>
   <data name="olvColumnInstallSource.Text" xml:space="preserve">
     <value>Nguồn cài đặt</value>
@@ -157,13 +157,13 @@
     <value>Loại trình gỡ cài đặt</value>
   </data>
   <data name="olvColumnSystemComponent.Text" xml:space="preserve">
-    <value>Thành phần Hệ thống</value>
+    <value>Thành phần hệ thống</value>
   </data>
   <data name="olvColumnProtected.Text" xml:space="preserve">
     <value>Được bảo vệ</value>
   </data>
   <data name="olvColumnRegistryKeyName.Text" xml:space="preserve">
-    <value>Khoá thanh ghi</value>
+    <value>Khoá registry</value>
   </data>
   <data name="olvColumnGuid.Text" xml:space="preserve">
     <value>Mã sản phẩm</value>
@@ -172,7 +172,7 @@
     <value>Câu lệnh gỡ cài đặt âm thầm</value>
   </data>
   <data name="toolStripButton1.Text" xml:space="preserve">
-    <value>Nạp lại trình gỡ cài đặt</value>
+    <value>Làm mới danh sách trình gỡ cài đặt</value>
   </data>
   <data name="toolStripButtonSelAll.Text" xml:space="preserve">
     <value>Chọn tất cả</value>
@@ -184,7 +184,7 @@
     <value>Đảo ngược lựa chọn</value>
   </data>
   <data name="toolStripButtonTarget.Text" xml:space="preserve">
-    <value>Gỡ cài đặt theo cửa sổ, thư mục hoặc tệp...</value>
+    <value>Gỡ cài đặt dựa vào cửa sổ, thư mục hoặc tệp...</value>
   </data>
   <data name="toolStripButtonUninstall.Text" xml:space="preserve">
     <value>Gỡ cài đặt</value>
@@ -193,7 +193,7 @@
     <value>Gỡ cài đặt âm thầm</value>
   </data>
   <data name="toolStripButtonModify.Text" xml:space="preserve">
-    <value>Điều chỉnh</value>
+    <value>Sửa đổi</value>
   </data>
   <data name="toolStripButtonProperties.Text" xml:space="preserve">
     <value>Thuộc tính</value>
@@ -217,19 +217,19 @@
     <value>&amp;Gỡ cài đặt</value>
   </data>
   <data name="quietUninstallContextMenuStripItem.Text" xml:space="preserve">
-    <value>Gỡ cài đặt &amp;âm thầm</value>
+    <value>Gỡ cài đặt âm &amp;thầm</value>
   </data>
   <data name="manualUninstallToolStripMenuItem1.Text" xml:space="preserve">
-    <value>Gỡ cài đặt &amp;thủ công</value>
+    <value>Gỡ cài đặt thủ &amp;công</value>
   </data>
   <data name="msiInstallContextMenuStripItem.Text" xml:space="preserve">
-    <value>&amp;Cài dặt hoặc cấu hình (/I)</value>
+    <value>&amp;Cài đặt hoặc cấu hình (/I)</value>
   </data>
   <data name="msiUninstallContextMenuStripItem.Text" xml:space="preserve">
     <value>&amp;Gỡ cài đặt (/X)</value>
   </data>
   <data name="msiQuietUninstallContextMenuStripItem.Text" xml:space="preserve">
-    <value>&amp;Gỡ cài đặt âm thầm (/X /qb)</value>
+    <value>Gỡ cài đặt âm &amp;thầm (/X /qb)</value>
   </data>
   <data name="uninstallUsingMsiExecContextMenuStripItem.Text" xml:space="preserve">
     <value>Gỡ cài đặt bằng &amp;MsiExec...</value>
@@ -241,7 +241,7 @@
     <value>Bao gồm</value>
   </data>
   <data name="runToolStripMenuItem.Text" xml:space="preserve">
-    <value>Chạy...</value>
+    <value>Khởi chạy...</value>
   </data>
   <data name="toolStripMenuItem9.Text" xml:space="preserve">
     <value>Nâng cao...</value>
@@ -256,34 +256,34 @@
     <value>Mã sản phẩm / GUID</value>
   </data>
   <data name="fullRegistryPathCopyContextMenuStripItem.Text" xml:space="preserve">
-    <value>Đường dẫn đầy đủ đến thanh ghi</value>
+    <value>Đường dẫn đầy đủ đến registry</value>
   </data>
   <data name="uninstallStringCopyContextMenuStripItem.Text" xml:space="preserve">
-    <value>Lệnh gỡ cài đặt</value>
+    <value>Câu lệnh gỡ cài đặt</value>
   </data>
   <data name="copyToClipboardContextMenuStripItem.Text" xml:space="preserve">
-    <value>&amp;Sao chép vào Bảng nhớ tạm...</value>
+    <value>&amp;Sao chép vào bảng nhớ tạm...</value>
   </data>
   <data name="deleteRegistryEntryContextMenuStripItem.Text" xml:space="preserve">
-    <value>&amp;Xoá mục thanh ghi</value>
+    <value>&amp;Xoá mục registry</value>
   </data>
   <data name="renameContextMenuStripItem.Text" xml:space="preserve">
-    <value>&amp;Đổi tên...</value>
+    <value>Đổi &amp;tên...</value>
   </data>
   <data name="installLocationOpenInExplorerContextMenuStripItem.Text" xml:space="preserve">
-    <value>&amp;Vị trí cài đặt</value>
+    <value>Vị trí &amp;cài đặt</value>
   </data>
   <data name="uninstallerLocationOpenInExplorerContextMenuStripItem.Text" xml:space="preserve">
-    <value>&amp;Vị trí Trình gỡ cài đặt</value>
+    <value>Vị trí &amp;trình gỡ cài đặt</value>
   </data>
   <data name="sourceLocationOpenInExplorerContextMenuStripItem.Text" xml:space="preserve">
-    <value>&amp;Vị trí Nguồn</value>
+    <value>Vị trí &amp;nguồn</value>
   </data>
   <data name="openInExplorerContextMenuStripItem.Text" xml:space="preserve">
     <value>Mở trong &amp;Explorer...</value>
   </data>
   <data name="openWebPageContextMenuStripItem.Text" xml:space="preserve">
-    <value>Mở &amp;Trang web</value>
+    <value>Mở Trang &amp;web</value>
   </data>
   <data name="toolStripMenuItem15.Text" xml:space="preserve">
     <value>Google</value>
@@ -307,7 +307,7 @@
     <value>FileHippo.com</value>
   </data>
   <data name="lookUpOnlineToolStripMenuItem.Text" xml:space="preserve">
-    <value>&amp;Tìm kiếm trực tuyến</value>
+    <value>Tìm &amp;kiếm trực tuyến</value>
   </data>
   <data name="rateToolStripMenuItem.Text" xml:space="preserve">
     <value>Đánh giá...</value>
@@ -322,10 +322,10 @@
     <value>Xuất các thuộc tính của trình gỡ cài đặt đã chọn</value>
   </data>
   <data name="reloadUninstallersToolStripMenuItem.Text" xml:space="preserve">
-    <value>&amp;Nạp lại trình gỡ cài đặt</value>
+    <value>&amp;Làm mới danh sách trình gỡ cài đặt</value>
   </data>
   <data name="loadUninstallerListToolStripMenuItem.Text" xml:space="preserve">
-    <value>&amp;Mở Danh sách Gỡ cài đặt...</value>
+    <value>&amp;Mở danh sách bộ lọc gỡ cài đặt...</value>
   </data>
   <data name="exportSelectedToolStripMenuItem.Text" xml:space="preserve">
     <value>&amp;Xuất dữ liệu của các trình gỡ cài đặt đã chọn...</value>
@@ -355,7 +355,7 @@
     <value>Hiển thị &amp;cài đặt ở cạnh bên</value>
   </data>
   <data name="displayStatusbarToolStripMenuItem.Text" xml:space="preserve">
-    <value>Hiển thị &amp;thanh trạng thái</value>
+    <value>Hiển thị th&amp;anh trạng thái</value>
   </data>
   <data name="useSystemThemeToolStripMenuItem.Text" xml:space="preserve">
     <value>&amp;Sử dụng chủ đề hệ thống</value>
@@ -367,28 +367,28 @@
     <value>&amp;Bộ lọc mặc định</value>
   </data>
   <data name="basicApplicationsToolStripMenuItem.Text" xml:space="preserve">
-    <value>Chỉ những &amp;ứng dụng cơ bản</value>
+    <value>Chỉ mình ứng &amp;dụng cơ bản</value>
   </data>
   <data name="systemComponentsToolStripMenuItem.Text" xml:space="preserve">
-    <value>Chỉ những thành phần hệ thống</value>
+    <value>Chỉ mình thành phần hệ thống</value>
   </data>
   <data name="everythingToolStripMenuItem.Text" xml:space="preserve">
     <value>&amp;Tất cả mọi thứ</value>
   </data>
   <data name="automaticallyStartedToolStripMenuItem.Text" xml:space="preserve">
-    <value>Chỉ những úng dụng tự động khởi chạy</value>
+    <value>Chỉ mình úng dụng tự động khởi chạy</value>
   </data>
   <data name="onlyWebBrowsersToolStripMenuItem.Text" xml:space="preserve">
-    <value>Chỉ những trình duyệt</value>
+    <value>Chỉ mình trình duyệt</value>
   </data>
   <data name="viewTweaksToolStripMenuItem.Text" xml:space="preserve">
-    <value>Xem tinh chỉnh hệ thống</value>
+    <value>Xem các tinh chỉnh</value>
   </data>
   <data name="viewUnregisteredToolStripMenuItem.Text" xml:space="preserve">
     <value>Xem các mục chưa đăng ký</value>
   </data>
   <data name="viewUpdatesToolStripMenuItem.Text" xml:space="preserve">
-    <value>Xem các mục cập nhật</value>
+    <value>Xem các ứng dụng cập nhật</value>
   </data>
   <data name="viewWindowsFeaturesToolStripMenuItem.Text" xml:space="preserve">
     <value>Xem Windows Features</value>
@@ -400,52 +400,52 @@
     <value>Tìm kiếm...</value>
   </data>
   <data name="filteringToolStripMenuItem.Text" xml:space="preserve">
-    <value>Bộ lọc nhanh</value>
+    <value>&amp;Bộ lọc</value>
   </data>
   <data name="uninstallToolStripMenuItem.Text" xml:space="preserve">
     <value>Gỡ cài đặt</value>
   </data>
   <data name="quietUninstallToolStripMenuItem.Text" xml:space="preserve">
-    <value>Gỡ cài đặt &amp;âm thầm</value>
+    <value>Gỡ cài đặt âm &amp;thầm</value>
   </data>
   <data name="modifyToolStripMenuItem.Text" xml:space="preserve">
-    <value>Điều chỉnh</value>
+    <value>Sửa đổi</value>
   </data>
   <data name="advancedClipCopyToolStripMenuItem.Text" xml:space="preserve">
-    <value>Nâng cao...</value>
+    <value>&amp;Nâng cao...</value>
   </data>
   <data name="copyFullInformationToolStripMenuItem.Text" xml:space="preserve">
     <value>&amp;Thông tin đầy đủ</value>
   </data>
   <data name="toolStripMenuItem10.Text" xml:space="preserve">
-    <value>Tên ứng dụng</value>
+    <value>Tên chương trình</value>
   </data>
   <data name="toolStripMenuItem11.Text" xml:space="preserve">
     <value>Mã sản phẩm / GUID</value>
   </data>
   <data name="toolStripMenuItem12.Text" xml:space="preserve">
-    <value>Đường dẫn đầy đủ đến thanh ghi</value>
+    <value>Đường dẫn đầy đủ đến registry</value>
   </data>
   <data name="toolStripMenuItem13.Text" xml:space="preserve">
-    <value>Lệnh gỡ cài đặt</value>
+    <value>Câu lệnh gỡ cài đặt</value>
   </data>
   <data name="toolStripMenuItem8.Text" xml:space="preserve">
-    <value>&amp;Sao chép vào Bảng nhớ tạm...</value>
+    <value>&amp;Sao chép vào bảng nhớ tạm...</value>
   </data>
   <data name="toolStripMenuItem5.Text" xml:space="preserve">
-    <value>&amp;Vị trí cài đặt</value>
+    <value>Vị trí &amp;cài đặt</value>
   </data>
   <data name="toolStripMenuItem6.Text" xml:space="preserve">
-    <value>&amp;Vị trí Trình gỡ cài đặt</value>
+    <value>Vị trí &amp;trình gỡ cài đặt</value>
   </data>
   <data name="toolStripMenuItem7.Text" xml:space="preserve">
-    <value>&amp;Vị trí nguồn</value>
+    <value>Vị trí &amp;nguồn</value>
   </data>
   <data name="toolStripMenuItem1.Text" xml:space="preserve">
     <value>Mở trong &amp;Explorer...</value>
   </data>
   <data name="toolStripMenuItem14.Text" xml:space="preserve">
-    <value>Mở &amp;Trang web</value>
+    <value>Mở trang &amp;web</value>
   </data>
   <data name="googleToolStripMenuItem.Text" xml:space="preserve">
     <value>Google</value>
@@ -469,7 +469,7 @@
     <value>FileHippo.com</value>
   </data>
   <data name="onlineSearchToolStripMenuItem.Text" xml:space="preserve">
-    <value>&amp;Tìm kiếm trực tuyến</value>
+    <value>Tìm &amp;kiếm trực tuyến</value>
   </data>
   <data name="rateToolStripMenuItem1.Text" xml:space="preserve">
     <value>Đánh giá...</value>
@@ -478,10 +478,10 @@
     <value>Hiển thị &amp;thuộc tính</value>
   </data>
   <data name="basicOperationsToolStripMenuItem.Text" xml:space="preserve">
-    <value>&amp;Thao tác cơ bản</value>
+    <value>Tính năng &amp;cơ bản</value>
   </data>
   <data name="manualUninstallToolStripMenuItem.Text" xml:space="preserve">
-    <value>Gỡ cài đặt &amp;thủ công</value>
+    <value>Gỡ cài đặt thủ &amp;công</value>
   </data>
   <data name="toolStripMenuItem2.Text" xml:space="preserve">
     <value>&amp;Cài đặt hoặc cấu hình (/I)</value>
@@ -493,16 +493,16 @@
     <value>&amp;Gỡ cài đặt âm thầm (/X /qb)</value>
   </data>
   <data name="msiUninstalltoolStripMenuItem.Text" xml:space="preserve">
-    <value>&amp;Gỡ cài đặt bằng MsiExec</value>
+    <value>Gỡ cài đặt bằng &amp;MsiExec</value>
   </data>
   <data name="renameToolStripMenuItem.Text" xml:space="preserve">
-    <value>&amp;Đổi tên...</value>
+    <value>Đổi &amp;tên...</value>
   </data>
   <data name="disableAutostartToolStripMenuItem.Text" xml:space="preserve">
     <value>Tắt tính năng tự khởi động</value>
   </data>
   <data name="deleteToolStripMenuItem.Text" xml:space="preserve">
-    <value>&amp;Xóa khóa thanh ghi</value>
+    <value>&amp;Xóa khóa registry</value>
   </data>
   <data name="createBackupToolStripMenuItem.Text" xml:space="preserve">
     <value>Tạo &amp;bản sao lưu...</value>
@@ -514,16 +514,16 @@
     <value>Lấy quyền sở hữu</value>
   </data>
   <data name="advancedOperationsToolStripMenuItem.Text" xml:space="preserve">
-    <value>&amp;Thao tác nâng cao</value>
+    <value>Tính năng &amp;nâng cao</value>
   </data>
   <data name="openStartupManagerToolStripMenuItem.Text" xml:space="preserve">
-    <value>Mở Trình quản lý Khởi động</value>
+    <value>Mở Trình quản lý Khởi động cùng hệ thống</value>
   </data>
   <data name="cleanUpProgramFilesToolStripMenuItem.Text" xml:space="preserve">
     <value>&amp;Dọn dẹp thư mục "Program Files"...</value>
   </data>
   <data name="targetMenuItem.Text" xml:space="preserve">
-    <value>Gỡ cài đặt theo cửa sổ, thư mục hoặc tệp...</value>
+    <value>Gỡ cài đặt dựa vào cửa sổ, thư mục hoặc tệp...</value>
   </data>
   <data name="uninstallFromDirectoryToolStripMenuItem.Text" xml:space="preserve">
     <value>Gỡ cài đặt từ thư mục...</value>
@@ -532,10 +532,10 @@
     <value>Giải quyết vấn đề gỡ cài đặt...</value>
   </data>
   <data name="startDiskCleanupToolStripMenuItem.Text" xml:space="preserve">
-    <value>Khởi chạy Dọn dẹp Đĩa</value>
+    <value>Khởi chạy dọn dẹp đĩa</value>
   </data>
   <data name="tryToInstallNETV35ToolStripMenuItem.Text" xml:space="preserve">
-    <value>Cài đặt .NET v3.5 (và các chức năng đi kèm)</value>
+    <value>Cài đặt .NET v3.5 (và các tính năng đi kèm)</value>
   </data>
   <data name="createRestorePointToolStripMenuItem.Text" xml:space="preserve">
     <value>Tạo một điểm khôi phục mới</value>
@@ -556,10 +556,10 @@
     <value>Mở &amp;trợ giúp</value>
   </data>
   <data name="startSetupWizardToolStripMenuItem.Text" xml:space="preserve">
-    <value>Khởi chạy Trợ lý Thiết lập</value>
+    <value>Khởi chạy trợ lý thiết lập</value>
   </data>
   <data name="checkForUpdatesToolStripMenuItem.Text" xml:space="preserve">
-    <value>Kiểm tra bản cập nhật</value>
+    <value>Kiểm tra các bản cập nhật</value>
   </data>
   <data name="submitFeedbackToolStripMenuItem.Text" xml:space="preserve">
     <value>Gửi phản hồi...</value>
@@ -571,16 +571,16 @@
     <value>Gỡ cài đặt BCUninstaller</value>
   </data>
   <data name="aboutToolStripMenuItem.Text" xml:space="preserve">
-    <value>&amp;Về</value>
+    <value>&amp;Giới thiệu</value>
   </data>
   <data name="helpToolStripMenuItem.Text" xml:space="preserve">
-    <value>&amp;Trợ giúp</value>
+    <value>Trợ &amp;giúp</value>
   </data>
   <data name="debugToolStripMenuItem.Text" xml:space="preserve">
-    <value>Mở &amp;cửa sổ gỡ lỗi</value>
+    <value>&amp;Mở cửa sổ gỡ lỗi</value>
   </data>
   <data name="createBackupFileDialog.Filter" xml:space="preserve">
-    <value>Tệp thanh ghi|*.reg</value>
+    <value>Tệp registry|*.reg</value>
   </data>
   <data name="createBackupFileDialog.Title" xml:space="preserve">
     <value>Tạo bản sao thanh ghi</value>

--- a/source/BulkCrapUninstaller/Forms/Windows/SettingsWindow.vi.resx
+++ b/source/BulkCrapUninstaller/Forms/Windows/SettingsWindow.vi.resx
@@ -118,17 +118,17 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="label5.Text" xml:space="preserve">
-    <value>Dòng lệnh trước khi gỡ cài đặt</value>
+    <value>Câu lệnh trước khi bắt đầu gỡ cài đặt</value>
   </data>
   <data name="label6.Text" xml:space="preserve">
-    <value>Dòng lệnh sau khi gỡ cài đặt</value>
+    <value>Câu lệnh sau khi gỡ cài đặt kết thúc</value>
   </data>
   <data name="checkBoxColorblind.Text" xml:space="preserve">
     <value>Chế độ mù màu</value>
     <comment>Switches colors to be better for color-blind people</comment>
   </data>
   <data name="checkBoxDpiaware.Text" xml:space="preserve">
-    <value>Kích hoạt tính năng điều chỉnh giao diện theo DPI</value>
+    <value>Bật tính năng tỷ lệ giao diện hỗ trợ DPI</value>
   </data>
   <data name="label3.Text" xml:space="preserve">
     <value>Nhấp đúp vào danh sách ứng dụng</value>
@@ -137,13 +137,13 @@
     <value>Lặt vặt</value>
   </data>
   <data name="checkBoxAutoLoad.Text" xml:space="preserve">
-    <value>Tự động nạp Danh sách gỡ cài đặt có tên "Default.bcul" khi khởi động</value>
+    <value>Tự động nạp danh sách bộ lọc gỡ cài đặt có tên "Default.bcul" khi khởi động</value>
   </data>
   <data name="checkBoxRatings.Text" xml:space="preserve">
     <value>Hiển thị xếp hạng người dùng cho ứng dụng</value>
   </data>
   <data name="checkBoxUpdateSearch.Text" xml:space="preserve">
-    <value>Tìm kiếm thông tin cập nhật khi khởi động</value>
+    <value>Kiểm tra các bản cập nhật khi khởi động</value>
   </data>
   <data name="checkBoxSendStats.Text" xml:space="preserve">
     <value>Gửi số liệu thống kê sử dụng ẩn danh</value>
@@ -170,7 +170,7 @@
     <value>Luôn hiển thị nội dung rác với độ tin cậy thấp</value>
   </data>
   <data name="checkBoxLoud.Text" xml:space="preserve">
-    <value>Yêu cầu xóa Trình gỡ cài đặt ồn ào khỏi tác vụ âm thầm</value>
+    <value>Yêu cầu xóa trình gỡ cài đặt gốc khỏi tác vụ âm thầm</value>
   </data>
   <data name="checkBoxNeverFeedback.Text" xml:space="preserve">
     <value>Không bao giờ yêu cầu phản hồi hoặc trợ giúp</value>
@@ -188,7 +188,7 @@
     <value>Cho phép thực thi các ứng dụng bên ngoài</value>
   </data>
   <data name="label7.Text" xml:space="preserve">
-    <value>Bạn có thể chỉ định các lệnh sẽ chạy trước và sau khi gỡ cài đặt. Mỗi dòng tương ứng với một lệnh và được thực thi như thể sử dụng hộp thoại "Run...".
+    <value>Bạn có thể chỉ định các câu lệnh sẽ thực thi trước và sau khi gỡ cài đặt. Mỗi dòng tương ứng với một lệnh và được thực thi như thể sử dụng hộp thoại "Khởi chạy...".
 
 BCU sẽ đợi cho đến khi lệnh hiện đang thực thi hoàn tất trước khi thực thi lệnh tiếp theo.</value>
   </data>
@@ -196,7 +196,7 @@ BCU sẽ đợi cho đến khi lệnh hiện đang thực thi hoàn tất trư�
     <value>Ứng dụng bên ngoài</value>
   </data>
   <data name="button2.Text" xml:space="preserve">
-    <value>&amp;Đóng</value>
+    <value>Đó&amp;ng</value>
   </data>
   <data name="tabPageGeneral.Text" xml:space="preserve">
     <value>Chung</value>
@@ -241,7 +241,7 @@ BCU sẽ đợi cho đến khi lệnh hiện đang thực thi hoàn tất trư�
     <value>Kho ứng dụng để quét</value>
   </data>
   <data name="checkBoxScanRegistry.Text" xml:space="preserve">
-    <value>Thanh ghi (khuyến khích để bật)</value>
+    <value>Registry (khuyến khích bật)</value>
   </data>
   <data name="checkBoxScanDrives.Text" xml:space="preserve">
     <value>Ổ đĩa (phát hiện các ứng dụng chưa đăng ký)</value>
@@ -259,18 +259,18 @@ BCU sẽ đợi cho đến khi lệnh hiện đang thực thi hoàn tất trư�
     <value>Công cụ bên ngoài</value>
   </data>
   <data name="checkBoxRemovable.Text" xml:space="preserve">
-    <value>Quét ổ đĩa di động</value>
+    <value>Quét các ổ đĩa di động</value>
     <comment>Scan pendrives, USB hard drives, SD Cards, etc.</comment>
   </data>
   <data name="checkBoxAutoInstallFolderDetect.Text" xml:space="preserve">
     <value>Cố gắng tự động phát hiện các thư mục cài đặt tùy chỉnh</value>
   </data>
   <data name="labelProgramFolders.Text" xml:space="preserve">
-    <value>Bạn có thể chỉ định các thư mục tùy chỉnh mà bạn cài đặt ứng dụng của mình vào (ví dụ: D:\Applications). Những thư mục đó sẽ được BCU sử dụng để tìm kiếm phần còn sót lại của quá trình gỡ cài đặt, các ứng dụng chưa đăng ký và một vài thứ khác. Mặc dù không cần thiết nhưng danh sách các thư mục này sẽ giúp BCU hoạt động tốt hơn.
+    <value>Bạn có thể thiết lập các thư mục cài đặt ứng dụng tùy chỉnh (ví dụ: D:\Applications). Những thư mục đó sẽ được BCU sẽ sử dụng các thư mục này để tìm kiếm các tệp sót lại sau khi gỡ cài đặt, các ứng dụng chưa đăng ký và một vài thứ khác. Mặc dù không bắt buộc, nhưng việc cung cấp danh sách các thư mục này sẽ giúp BCU hoạt động hiệu quả hơn.
 
 Các thư mục mặc định của Windows luôn được quét, bạn không cần đưa chúng vào danh sách này.
 
-Sử dụng đường dẫn thư mục đầy đủ, một đường dẫn trên mỗi dòng. Đường dẫn không hợp lệ và thư mục không tồn tại sẽ bị bỏ qua.</value>
+Hãy sử dụng đường dẫn thư mục đầy đủ, một dòng một đường dân. Đường dẫn không hợp lệ và thư mục không tồn tại sẽ bị bỏ qua.</value>
   </data>
   <data name="groupBoxProgramFolders.Text" xml:space="preserve">
     <value>Thư mục cài đặt ứng dụng</value>
@@ -279,7 +279,7 @@ Sử dụng đường dẫn thư mục đầy đủ, một đường dẫn trên
     <value>Thư mục</value>
   </data>
   <data name="groupBox2.Text" xml:space="preserve">
-    <value>Khởi động</value>
+    <value>Khởi động cùng hệ thống</value>
   </data>
   <data name="groupBox3.Text" xml:space="preserve">
     <value>Mạng</value>

--- a/source/BulkCrapUninstaller/Forms/Windows/UninstallProgressWindow.vi.resx
+++ b/source/BulkCrapUninstaller/Forms/Windows/UninstallProgressWindow.vi.resx
@@ -127,7 +127,7 @@
     <value>Trạng thái</value>
   </data>
   <data name="olvColumnIsSilent.Text" xml:space="preserve">
-    <value>Âm thầm</value>
+    <value>Gỡ âm thầm</value>
   </data>
   <data name="olvColumnName.Text" xml:space="preserve">
     <value>Tên</value>
@@ -142,7 +142,7 @@
     <value>Chấm dứt</value>
   </data>
   <data name="runNowToolStripMenuItem.Text" xml:space="preserve">
-    <value>Khởi chạy trình gỡ cài đặt ngay bây giờ</value>
+    <value>Khởi chạy ngay bây giờ</value>
   </data>
   <data name="manualUninstallToolStripMenuItem.Text" xml:space="preserve">
     <value>Gỡ cài đặt thủ công</value>
@@ -155,7 +155,7 @@
   </data>
   <data name="label3.Text" xml:space="preserve">
     <value>Các trình gỡ cài đặt đã chọn sẽ được chạy lần lượt.
-Nếu một quá trình có vẻ bị kẹt, bạn có thể nhấp vào nút "Bỏ qua" để tránh các tác vụ bị kẹt. Quá trình gỡ cài đặt bị kẹt có thể xảy ra khi trình gỡ cài đặt gặp sự cố, bắt đầu một quy trình mới hoặc không đóng quy trình đó.</value>
+Nếu quá trình dường như bị kẹt, bạn có thể nhấp vào nút "Bỏ qua" để tránh phải đợi nó hoàn thành. Điều này có thể xảy ra nếu trình gỡ cài đặt bị lỗi hoặc khởi chạy một tiến trình mới và không đóng nó lại.</value>
   </data>
   <data name="toolStripButtonRun.Text" xml:space="preserve">
     <value>Khởi chạy trình gỡ cài đặt</value>
@@ -170,7 +170,7 @@ Nếu một quá trình có vẻ bị kẹt, bạn có thể nhấp vào nút "B
     <value>Gỡ cài đặt thủ công</value>
   </data>
   <data name="toolStripButtonFolderOpen.Text" xml:space="preserve">
-    <value>Mở vị trí cài đặt</value>
+    <value>Mở thư mục cài đặt</value>
   </data>
   <data name="toolStripButtonProperties.Text" xml:space="preserve">
     <value>Thuộc tính</value>
@@ -188,7 +188,7 @@ Nếu một quá trình có vẻ bị kẹt, bạn có thể nhấp vào nút "B
     <value>Danh sách trình gỡ cài đặt</value>
   </data>
   <data name="checkBoxFinishSleep.Text" xml:space="preserve">
-    <value>Đặt PC của bạn vào chế độ ngủ khi hoàn tất</value>
+    <value>Thiết lập PC của bạn vào chế độ ngủ khi hoàn tất</value>
   </data>
   <data name="$this.Text" xml:space="preserve">
     <value>Tiến trình gỡ cài đặt</value>

--- a/source/BulkCrapUninstaller/Forms/Wizards/BeginUninstallTaskWizard.vi.resx
+++ b/source/BulkCrapUninstaller/Forms/Wizards/BeginUninstallTaskWizard.vi.resx
@@ -130,7 +130,7 @@
     <value>Tiếp tục</value>
   </data>
   <data name="tabPage1.Text" xml:space="preserve">
-    <value>Liên quan</value>
+    <value>Có liên quan đến</value>
   </data>
   <data name="tabPage2.Text" xml:space="preserve">
     <value>Xác nhận</value>
@@ -169,7 +169,7 @@
     <value>l</value>
   </data>
   <data name="label11.Text" xml:space="preserve">
-    <value>Đang được dùng bởi tiến trình khác</value>
+    <value>Đang được sử dụng bởi tiến trình khác</value>
   </data>
   <data name="labelTotalSize.Text" xml:space="preserve">
     <value>l</value>
@@ -181,30 +181,30 @@
     <value>l</value>
   </data>
   <data name="label7.Text" xml:space="preserve">
-    <value>Các ứng dụng để gỡ cài đặt</value>
+    <value>Các ứng dụng cần gỡ cài đặt</value>
   </data>
   <data name="button2.Text" xml:space="preserve">
-    <value>KHỞI ĐỘNG QUÁ TRÌNH GỠ CÀI ĐẶT</value>
+    <value>BẮT ĐẦU QUÁ TRÌNH GỠ CÀI ĐẶT</value>
   </data>
   <data name="tabPage5.Text" xml:space="preserve">
-    <value>Hoàn thành</value>
+    <value>Phần cuối</value>
   </data>
   <data name="p1Heading.Text" xml:space="preserve">
-    <value>Các ứng dụng liên quan cần gỡ cài đặt</value>
+    <value>Các ứng dụng có liên quan mà bạn có thể muốn gỡ cài đặt</value>
   </data>
   <data name="label1.Text" xml:space="preserve">
     <value>Xác nhận rằng những mục dưới đây không có vấn đề gì khi gỡ cài đặt</value>
   </data>
   <data name="label2.Text" xml:space="preserve">
-    <value>Một số ứng dụng cần phải đóng trước khi gỡ cài đặt.</value>
+    <value>Một số ứng dụng có thể cần được đóng lại trước khi gỡ cài đặt</value>
   </data>
   <data name="label5.Text" xml:space="preserve">
-    <value>Thay đổi cài đặt của quá trình gỡ cài đặt</value>
+    <value>Thay đổi cài đặt mặc định của bạn</value>
   </data>
   <data name="label6.Text" xml:space="preserve">
-    <value>Vui lòng xác nhận rằng thông tin sau là chính xác trước khi bắt đầu gỡ cài đặt. Đây là cơ hội cuối cùng của bạn!</value>
+    <value>Vui lòng xác nhận rằng tất cả thông tin dưới đây là chính xác trước khi bắt đầu gỡ cài đặt. Đây là lần cơ hội cuối cùng của bạn!</value>
   </data>
   <data name="$this.Text" xml:space="preserve">
-    <value>Khởi động tác vụ gỡ cài đặt mới</value>
+    <value>Bắt đầu quá trình gỡ cài đặt mới</value>
   </data>
 </root>

--- a/source/BulkCrapUninstaller/Forms/Wizards/FirstStartBox.vi.resx
+++ b/source/BulkCrapUninstaller/Forms/Wizards/FirstStartBox.vi.resx
@@ -130,7 +130,7 @@
     <value>Tiếp tục</value>
   </data>
   <data name="buttonMore.Text" xml:space="preserve">
-    <value>Thêm cài đặt</value>
+    <value>Xem thêm cài đặt</value>
   </data>
   <data name="buttonHelp.Text" xml:space="preserve">
     <value>Xem trợ giúp</value>
@@ -139,13 +139,13 @@
     <value>Hoàn thành thiết lập</value>
   </data>
   <data name="p5finishContact.Text" xml:space="preserve">
-    <value>Bây giờ bạn có thể bắt đầu sử dụng BCUninstaller. Nếu bạn có bất kỳ câu hỏi hoặc đề xuất nào về các tính năng mới, vui lòng liên hệ với chúng tôi bằng liên kết bên dưới.</value>
+    <value>Bạn có thể bắt đầu sử dụng BCUninstaller ngay bây giờ. Nếu bạn có bất kỳ câu hỏi nào hay muốn đề xuất một tính năng mới, hãy truy cập vào liên kết dưới đây.</value>
   </data>
   <data name="p5LinkContact.Text" xml:space="preserve">
     <value>Mở biểu mẫu liên hệ</value>
   </data>
   <data name="p5finishHomepage.Text" xml:space="preserve">
-    <value>Bạn có thể kiểm tra nhật ký thay đổi phần mềm của tôi trên trang chủ.</value>
+    <value>Bạn có thể xem chi tiết nhật ký thay đổi và khám phá thêm các phần mềm khác của tôi trên trang chủ.</value>
   </data>
   <data name="p5LinkHomepage.Text" xml:space="preserve">
     <value>Mở trang chủ</value>
@@ -160,7 +160,7 @@
     <value>BCUninstaller có thể cố gắng kết nối Internet vì những lý do sau: </value>
   </data>
   <data name="p4netDesc1.Text" xml:space="preserve">
-    <value>● Để tìm kiếm các bản cập nhật cho ứng dụng.</value>
+    <value>● Để kiểm tra các bản cập nhật.</value>
   </data>
   <data name="p4netDesc2.Text" xml:space="preserve">
     <value>● Để tải lên các báo cáo lỗi.</value>
@@ -169,16 +169,16 @@
     <value>● Để gửi số liệu thống kê sử dụng ẩn danh.</value>
   </data>
   <data name="p4netDesc4.Text" xml:space="preserve">
-    <value>● Để tìm nạp và tải lên đánh giá ứng dụng.</value>
+    <value>● Để tìm và tải lên các đánh giá ứng dụng.</value>
   </data>
   <data name="p4netErrors.Text" xml:space="preserve">
-    <value>Bất cứ khi nào xảy ra lỗi, bạn sẽ được hỏi có muốn gửi hay không. Bạn có thể xem dữ liệu nào được gửi trong báo cáo lỗi và sử dụng bằng cách xem lại các tệp XML tương ứng của chúng trong thư mục BCUninstaller. Dữ liệu được gửi sẽ không được chia sẻ với bên thứ ba.</value>
+    <value>Mỗi khi xảy ra lỗi, bạn sẽ được hỏi xem có muốn gửi báo cáo lỗi đó không. Bạn có thể kiểm tra dữ liệu nào đang được gửi trong các báo cáo lỗi và sử dụng bằng cách kiểm tra các file XML tương ứng trong thư mục của BCUninstaller. Dữ liệu được gửi đi không được chia sẻ với bất kỳ bên thứ ba nào.</value>
   </data>
   <data name="checkBoxUpdateSearch.Text" xml:space="preserve">
-    <value>Tự động tìm kiếm các bản cập nhật khi ứng dụng khởi động</value>
+    <value>Tự động kiểm tra các bản cập nhật khi khởi động ứng dụng</value>
   </data>
   <data name="p4netUpdateAdd.Text" xml:space="preserve">
-    <value>Bạn có thể tìm kiếm các bản cập nhật theo cách thủ công từ thanh menu.</value>
+    <value>Bạn có thể kiểm tra cập nhật thủ công từ thanh menu.</value>
   </data>
   <data name="checkBoxSendStats.Text" xml:space="preserve">
     <value>Tự động gửi số liệu thống kê sử dụng ẩn danh</value>
@@ -187,19 +187,19 @@
     <value>Gửi những số liệu thống kê này có thể giúp cải thiện BCUninstaller.</value>
   </data>
   <data name="checkBoxRatings.Text" xml:space="preserve">
-    <value>Kích hoạt đánh giá ứng dụng của người dùng</value>
+    <value>Bật tính năng đánh giá ứng dụng của người dùng</value>
   </data>
   <data name="pCorTitle.Text" xml:space="preserve">
     <value>Trình gỡ cài đặt bị hỏng</value>
   </data>
   <data name="pCorDesc.Text" xml:space="preserve">
-    <value>Theo thời gian, bạn có thể nhận thấy rằng một số ứng dụng từ chối gỡ cài đặt hoặc biến mất khỏi hầu hết các trình quản lý gỡ cài đặt.</value>
+    <value>Theo thời gian, bạn có thể gặp phải tình trạng một số ứng dụng không thể gỡ cài đặt theo cách thông thường, hoặc chúng biến mất khỏi danh sách của hầu hết các công cụ gỡ cài đặt.</value>
   </data>
   <data name="pCorViewInvalidTitle.Text" xml:space="preserve">
     <value>Trình gỡ cài đặt bị hỏng hoặc bị thiếu</value>
   </data>
   <data name="pCorViewInvalid.Text" xml:space="preserve">
-    <value>Đôi khi trình gỡ cài đặt bị hỏng khiến việc gỡ cài đặt không thể thực hiện được. BCUninstaller cho phép bạn dễ dàng xóa các mục này bằng tùy chọn "Gỡ cài đặt thủ công".</value>
+    <value>Đôi khi trình gỡ cài đặt có thể bị lỗi, khiến bạn không thể gỡ cài đặt phần mềm theo cách thông thường. BCUninstaller có thể dễ dàng loại bỏ các chương trình này bằng cách sử dụng tùy chọn "Gỡ cài đặt thủ công".</value>
   </data>
   <data name="checkBoxInvalidTest.Text" xml:space="preserve">
     <value>Đánh dấu các trình gỡ cài đặt không hợp lệ</value>
@@ -208,99 +208,100 @@
     <value>Trình gỡ cài đặt không hợp lệ được đánh dấu bằng màu xám.</value>
   </data>
   <data name="pCorOrphansTitle.Text" xml:space="preserve">
-    <value>Ứng dụng chưa được đăng ký</value>
+    <value>Ứng dụng chưa đăng ký</value>
   </data>
   <data name="pCorOrphansMessage.Text" xml:space="preserve">
-    <value>Đôi khi toàn bộ ứng dụng có thể bị bỏ lại trên ổ đĩa của bạn ngay cả sau khi đã gỡ cài đặt. Điều này cũng có thể xảy ra nếu chỉ gỡ bỏ trình gỡ cài đặt.</value>
+    <value>Đôi khi toàn bộ ứng dụng vẫn có thể còn sót lại trên ổ đĩa của bạn ngay cả sau khi gỡ cài đặt. Điều này cũng có thể xảy ra khi chỉ có mỗi trình gỡ cài đặt được xoá.</value>
   </data>
   <data name="checkBoxOrphans.Text" xml:space="preserve">
-    <value>Hiển thị các ứng dụng chưa được đăng ký trong danh sách</value>
+    <value>Hiển thị các ứng dụng chưa đăng ký</value>
   </data>
   <data name="pCorOrphansComment.Text" xml:space="preserve">
     <value>Các ứng dụng chưa đăng ký được đánh dấu bằng màu đỏ.
-Nếu bạn không thể tìm thấy trình gỡ cài đặt gốc, bạn sẽ cần xóa nó bằng tùy chọn "Gỡ cài đặt thủ công".</value>
+Nếu bạn không thể tìm thấy trình gỡ cài đặt gốc, bạn sẽ cần xóa chúng bằng tùy chọn "Gỡ cài đặt thủ công".</value>
   </data>
   <data name="p3advTitle.Text" xml:space="preserve">
     <value>Dành cho người dùng nâng cao</value>
   </data>
   <data name="p3advDesc.Text" xml:space="preserve">
-    <value>Trong khi BCUninstaller có thể được sử dụng như một trình gỡ cài đặt cơ bản, nhưng hầu hết các tính năng của nó đều nhắm đến người dùng thành thạo. Hãy tiến hành thận trọng!</value>
+    <value>Mặc dù BCUninstaller có thể được sử dụng như một trình gỡ cài đặt cơ bản, nhưng hầu hết các chức năng của nó đều hướng đến người dùng chuyên sâu. Hãy cẩn thận khi sử dụng!</value>
   </data>
   <data name="p3advSyscompTitle.Text" xml:space="preserve">
     <value>Thành phần hệ thống</value>
   </data>
   <data name="p3advSyscomp.Text" xml:space="preserve">
-    <value>Các ứng dụng được đánh dấu là "Thành phần hệ thống" bị ẩn khỏi hầu hết các trình quản lý gỡ cài đặt cơ bản. Thẻ này KHÔNG có nghĩa là ứng dụng đó là một phần của hệ điều hành.</value>
+    <value>Các ứng dụng được đánh dấu là "thành phần hệ thống" thường bị ẩn khỏi hầu hết các trình gỡ cài đặt cơ bản. Tuy nhiên, điều này KHÔNG CÓ NGHĨA là ứng dụng đó là một phần của hệ điều hành.</value>
   </data>
   <data name="checkBoxListSysComp.Text" xml:space="preserve">
     <value>Hiển thị các trình gỡ cài đặt được đánh dấu là "thành phần hệ thống"</value>
   </data>
   <data name="p3advProtectTitle.Text" xml:space="preserve">
-    <value>Các trình gỡ cài đặt được bảo vệ</value>
+    <value>Trình gỡ cài đặt được bảo vệ</value>
   </data>
   <data name="p3advProtect.Text" xml:space="preserve">
-    <value>Các mục được bảo vệ được đánh dấu bằng thẻ "NoRemove", có nghĩa là nhà xuất bản không muốn bạn xóa chúng. Thẻ này thường được các gói phần mềm lớn sử dụng để ngăn bạn gỡ cài đặt các phần riêng lẻ của chúng.</value>
+    <value>Các mục được bảo vệ được đánh dấu bằng thẻ "NoRemove", có nghĩa là nhà phát hành không muốn bạn xóa chúng. Thẻ này thường được các gói phần mềm lớn sử dụng để ngăn bạn gỡ cài đặt các phần riêng lẻ của chúng.</value>
   </data>
   <data name="checkBoxListProtected.Text" xml:space="preserve">
     <value>Hiển thị các trình gỡ cài đặt được đánh dấu là "được bảo vệ"</value>
   </data>
   <data name="checkBoxDiisableProtection.Text" xml:space="preserve">
-    <value>Tắt tính năng bảo vệ của trình gỡ cài đặt được đánh dấu là "được bảo vệ"</value>
+    <value>Tắt tính năng bảo vệ của các trình gỡ cài đặt được đánh dấu
+là "được bảo vệ"</value>
   </data>
   <data name="p3advProtectAdd.Text" xml:space="preserve">
-    <value>Điều này sẽ cho phép bạn gỡ cài đặt các mục được bảo vệ.</value>
+    <value>Tính năng này sẽ cho phép bạn gỡ cài đặt các mục được bảo vệ.</value>
   </data>
   <data name="p2viewTitle.Text" xml:space="preserve">
     <value>Chế độ xem danh sách trình gỡ cài đặt</value>
   </data>
   <data name="p2viewDetail.Text" xml:space="preserve">
-    <value>Tất cả các trình gỡ cài đặt được tìm thấy trên hệ thống của bạn sẽ được hiển thị trong chế độ xem danh sách chính. Dưới đây là một số cách để xem dữ liệu này: </value>
+    <value>Tất cả các trình gỡ cài đặt được tìm thấy trong hệ thống của bạn đều có trong danh sách chính. Dưới đây là một số cách để duyệt qua dữ liệu này:</value>
   </data>
   <data name="p2viewDetail1.Text" xml:space="preserve">
-    <value>● Có thể tìm kiếm từ khóa bằng bộ lọc.</value>
+    <value>● Sử dụng bộ lọc và tìm kiếm theo từ khóa (tất cả các cột)</value>
   </data>
   <data name="p2viewDetail2.Text" xml:space="preserve">
-    <value>● Có thể sắp xếp trình gỡ cài đặt theo cột bất kỳ và có thể sắp xếp lại các cột theo ý muốn.</value>
+    <value>● Sắp xếp các trình gỡ cài đặt theo bất kỳ cột nào và bạn có thể sắp xếp lại các cột theo ý muốn.</value>
   </data>
   <data name="p2viewDetail3.Text" xml:space="preserve">
     <value>● Nhóm các trình gỡ cài đặt tương tự lại với nhau.</value>
   </data>
   <data name="checkBoxGroups.Text" xml:space="preserve">
-    <value>Hiển thị trình gỡ cài đặt theo nhóm</value>
+    <value>Hiển thị các trình gỡ cài đặt theo nhóm</value>
   </data>
   <data name="checkBoxCheckboxes.Text" xml:space="preserve">
-    <value>Chọn bằng cách sử dụng hộp kiểm</value>
+    <value>Chọn bằng cách tích vào hộp kiểm</value>
   </data>
   <data name="p2viewCertsTitle.Text" xml:space="preserve">
-    <value>Trình gỡ cài đặt được chứng nhận</value>
+    <value>Trình gỡ cài đặt đã đạt chứng chỉ</value>
   </data>
   <data name="p2viewCerts.Text" xml:space="preserve">
-    <value>Trình gỡ cài đặt có thể được ký bằng chứng chỉ do cơ quan có liên quan cấp. Nếu quá trình xác thực chứng chỉ đạt thì gói phần mềm chưa bị sửa đổi và có thể tin cậy được.</value>
+    <value>Trình gỡ cài đặt có thể được ký bằng chứng chỉ do các tổ chức uy tín cấp. Nếu chứng chỉ vượt qua xác thực, thì gói phần mềm chưa bị can thiệp và có uy tín.</value>
   </data>
   <data name="checkBoxCertTest.Text" xml:space="preserve">
-    <value>Đánh dấu các trình gỡ cài đặt được chứng nhận</value>
+    <value>Đánh dấu các trình gỡ cài đặt đạt chứng chỉ</value>
   </data>
   <data name="p2viewAdd.Text" xml:space="preserve">
-    <value>Trình gỡ cài đặt đã được xác minh được đánh dấu bằng màu xanh lá cây, trình gỡ cài đặt chưa được xác minh có màu xanh lam.
-Cảnh báo: Quá trình xác minh có thể mất nhiều thời gian.</value>
+    <value>Trình gỡ cài đặt được xác minh được đánh dấu màu xanh lục, trình gỡ cài đặt chưa được xác minh được đánh dấu màu xanh lam.
+Cảnh báo: Việc xác minh có thể mất nhiều thời gian.</value>
   </data>
   <data name="p1welcomeHeading.Text" xml:space="preserve">
     <value>Chào mừng bạn đến với BCUninstaller!</value>
   </data>
   <data name="p1welcomeSubheading.Text" xml:space="preserve">
-    <value>Trình hướng dẫn này sẽ cung cấp cho bạn xem tổng quan nhanh và giúp định cấu hình ứng dụng.</value>
+    <value>Trình hướng dẫn này sẽ cung cấp cho bạn một bản tóm tắt nhanh và hỗ trợ cấu hình ứng dụng.</value>
   </data>
   <data name="p1languageHeading.Text" xml:space="preserve">
     <value>Ngôn ngữ đã chọn</value>
   </data>
   <data name="p1languageDesc.Text" xml:space="preserve">
-    <value>Bạn có thể buộc BCUninstaller sử dụng một bản địa hóa cụ thể nếu ngôn ngữ mặc định không chính xác. Việc khởi động lại sẽ được thực hiện để áp dụng ngôn ngữ mới.</value>
+    <value>Bạn có thể buộc BCUninstaller sử dụng một cụ thể nếu ngôn ngữ mặc định không chính xác. Để áp dụng ngôn ngữ mới, chương trình cần sẽ cần phải khởi động lại.</value>
   </data>
   <data name="buttonLanguageApply.Text" xml:space="preserve">
     <value>Chấp nhận</value>
   </data>
   <data name="p1languageExtradetails.Text" xml:space="preserve">
-    <value>Nếu bạn muốn giúp dịch BCUninstaller sang ngôn ngữ của bạn, vui lòng liên hệ với chúng tôi bằng cách nhấp vào liên kết bên dưới. Mọi sự hợp tác đều được đánh giá cao!</value>
+    <value>Nếu bạn sẵn lòng giúp đỡ dịch BCUninstaller sang ngôn ngữ mẹ đẻ của bạn, hãy nhấp vào liên kết bên dưới để liên hệ với tôi. Mọi sự trợ giúp đều được trân trọng!</value>
   </data>
   <data name="p1linkLabelContact.Text" xml:space="preserve">
     <value>Mở biểu mẫu liên hệ</value>

--- a/source/BulkCrapUninstaller/Properties/Localisable.vi.resx
+++ b/source/BulkCrapUninstaller/Properties/Localisable.vi.resx
@@ -121,33 +121,33 @@
     <value>Đang tạo một điểm khôi phục mới...</value>
   </data>
   <data name="LoadingDialogTitleLookingForJunk" xml:space="preserve">
-    <value>Đang tìm kiếm các phần còn sót lại...</value>
+    <value>Đang kiểm tra các phần còn sót lại...</value>
   </data>
   <data name="LoadingDialogTitlePopulatingList" xml:space="preserve">
-    <value>Đang cập nhật danh sách các trình gỡ cài đặt</value>
+    <value>Đang cập nhật danh sách các trình gỡ cài đặt...</value>
   </data>
   <data name="LoadingDialogTitleRemovingJunk" xml:space="preserve">
     <value>Đang loại bỏ các phần còn sót lại...</value>
   </data>
   <data name="LoadingDialogTitleSearchingForUpdates" xml:space="preserve">
-    <value>Đang tìm kiếm bản cập nhật...</value>
+    <value>Đang kiểm tra các bản cập nhật...</value>
   </data>
   <data name="SearchNothingFoundMessage" xml:space="preserve">
     <value>Không có mục nào phù hợp với tiêu chí tìm kiếm của bạn.</value>
   </data>
   <data name="StrExportHeader" xml:space="preserve">
     <value>Xuất BCUninstaller
-Nhà xuất bản | Phiên bản | Ngày | Kích thước | Thanh ghi | Loại trình gỡ cài đặt | Lệnh gỡ cài đặt | Lệnh gỡ cài đặt âm thầm | Chú thích</value>
+Nhà phát hành | Phiên bản | Ngày | Kích thước | Regsitry | Loại trình gỡ cài đặt | Câu lệnh gỡ cài đặt | Câu lệnh gỡ cài đặt âm thầm | Chú thích</value>
   </data>
   <data name="StrIsPortable" xml:space="preserve">
-    <value>Phiên bản di động</value>
+    <value> Portable</value>
     <comment>keep space in front</comment>
   </data>
   <data name="SysRestoreGenericError" xml:space="preserve">
     <value>Gọi API không thành công</value>
   </data>
   <data name="MessageBoxes_BackupFailedQuestion_Message" xml:space="preserve">
-    <value>Sao lưu thanh ghi không thành công, bạn có muốn tiếp tục không?</value>
+    <value>Sao lưu registry không thành công, bạn có muốn tiếp tục chứ?</value>
   </data>
   <data name="MessageBoxes_BackupFailedQuestion_Details" xml:space="preserve">
     <value>Chi tiết lỗi: </value>
@@ -163,12 +163,12 @@ Chi tiết lỗi:
     <comment>Add space or newline afterwards and two newlines before</comment>
   </data>
   <data name="MessageBoxes_BackupRegistryQuestion_Message" xml:space="preserve">
-    <value>Bạn có muốn sao lưu thanh ghi trước khi tiếp tục không?</value>
+    <value>Bạn có muốn sao lưu registry trước khi tiếp tục không?</value>
   </data>
   <data name="MessageBoxes_BackupRegistryQuestion_Details" xml:space="preserve">
-    <value>Bạn sẽ có thể khôi phục tất cả các thay đổi bằng cách nhấp đúp vào nó sau đó.
+    <value>Bạn có thể hoàn tác mọi thay đổi bằng cách nhấp đúp vào nó sau này.
 
-Các tập tin và thư mục sẽ được chuyển vào Thùng rác, nơi chúng có thể được khôi phục.</value>
+Các tệp và thư mục sẽ được chuyển vào thùng rác, bạn có thể khôi phục chúng từ đó.</value>
   </data>
   <data name="MessageBoxes_CanSelectOnlyOneItemInfo_Title" xml:space="preserve">
     <value>Thao tác thất bại</value>
@@ -177,10 +177,10 @@ Các tập tin và thư mục sẽ được chuyển vào Thùng rác, nơi chú
     <value>Thao tác này chỉ yêu cầu một mục được chọn.</value>
   </data>
   <data name="MessageBoxes_CanSelectOnlyOneItemInfo_Details" xml:space="preserve">
-    <value>Chọn chính xác một trình gỡ cài đặt từ danh sách. Nếu bạn đang sử dụng các hộp kiểm, hãy nhớ chọn chúng.</value>
+    <value>Chọn chính xác một trình gỡ cài đặt từ danh sách. Nếu có các hộp kiểm, hãy nhớ tích vào chúng.</value>
   </data>
   <data name="MessageBoxes_Title_Search_for_updates" xml:space="preserve">
-    <value>Tìm kiếm bản cập nhật</value>
+    <value>Kiểm tra các bản cập nhật</value>
   </data>
   <data name="MessageBoxes_NoNetworkConnected_Open_online_content" xml:space="preserve">
     <value>Mở nội dung trực tuyến</value>
@@ -189,7 +189,7 @@ Các tập tin và thư mục sẽ được chuyển vào Thùng rác, nơi chú
     <value>Không thể kết nối Internet hoặc không có mạng.</value>
   </data>
   <data name="MessageBoxes_NoNetworkConnected_Details" xml:space="preserve">
-    <value>Đảm bảo rằng cáp mạng của bạn đã được cắm. Nếu bạn đang sử dụng Wi-Fi, hãy đảm bảo rằng bạn có cường độ tín hiệu tốt.</value>
+    <value>Đảm bảo rằng cáp mạng của bạn đã được cắm. Và nếu bạn đang sử dụng Wi-Fi, hãy đảm bảo rằng bạn có cường độ tín hiệu tốt.</value>
   </data>
   <data name="MessageBoxes_Title_Submit_feedback" xml:space="preserve">
     <value>Gửi phản hồi</value>
@@ -198,7 +198,7 @@ Các tập tin và thư mục sẽ được chuyển vào Thùng rác, nơi chú
     <value>Bạn có muốn gửi phản hồi liên quan về BCU không?</value>
   </data>
   <data name="MessageBoxes_AskToSubmitFeedback_Details" xml:space="preserve">
-    <value>Nhiệm vụ này chỉ mất chưa đầy một phút nhưng nó sẽ góp phần rất lớn vào sự phát triển của bạn! Mọi phản hồi đều được đánh giá cao, cho dù đó là báo cáo lỗi, yêu cầu tính năng hay chỉ là một lời cảm ơn đơn giản!
+    <value>Sẽ chỉ mất của bạn chưa đến một phút nhưng lại giúp ích rất nhiều cho việc phát triển! Mọi phản hồi đều được ghi nhận, cho dù đó là báo lỗi, yêu cầu tính năng mới hay chỉ đơn giản là lời cảm ơn!
 
 Bạn có thể gửi nó sau từ thanh menu trên cùng (Trợ giúp -&gt; Gửi phản hồi).</value>
   </data>
@@ -206,22 +206,22 @@ Bạn có thể gửi nó sau từ thanh menu trên cùng (Trợ giúp -&gt; G�
     <value>Phiên bản hiện tại là phiên bản mới nhất</value>
   </data>
   <data name="MessageBoxes_UpdateUptodate_Details" xml:space="preserve">
-    <value>Không có bản cập nhật nào được tìm thấy vào thời điểm này, vì vậy đây là phiên bản mới nhất.
+    <value>Hiện tại không tìm thấy bản cập nhật nào, bạn đang dùng phiên bản mới nhất.
 
-Bạn muốn thêm một số chức năng hoặc sửa lỗi? Vui lòng gửi cho tôi phản hồi của bạn bằng cách sử dụng menu "Trợ giúp-&gt;Gửi phản hồi".</value>
+Bạn có muốn đề xuất thêm tính năng hoặc báo cáo lỗi không? Vui lòng gửi cho tôi phản hồi của bạn bằng cách sử dụng menu "Trợ giúp-&gt;Gửi phản hồi".</value>
   </data>
   <data name="MessageBoxes_UpdateFailed_Message" xml:space="preserve">
-    <value>Đã xảy ra lỗi khi kiểm tra cập nhật</value>
+    <value>Đã xảy ra lỗi khi kiểm tra các bản cập nhật</value>
   </data>
   <data name="MessageBoxes_UpdateFailed_Details" xml:space="preserve">
     <value>Hãy đảm bảo rằng BCUninstaller không bị chặn bởi tường lửa và bạn đã kết nối Internet.</value>
   </data>
   <data name="MessageBoxes_UpdateAskToDownload_Message" xml:space="preserve">
-    <value>Đã có phiên bản mới {0}, bạn có muốn nâng cấp ngay bây giờ không?</value>
+    <value>Đã có phiên bản mới {0}, bạn có muốn nâng cấp ngay không?</value>
     <comment>0 is version number</comment>
   </data>
   <data name="MessageBoxes_UpdateAskToDownload_Details" xml:space="preserve">
-    <value>BCUninstaller sẽ tự động tải xuống các bản cập nhật và áp dụng chúng sau khi khởi động lại. Xin lưu ý rằng cài đặt của bạn có thể bị mất trong trường hợp này.
+    <value>BCUninstaller sẽ tự động tải xuống bản các cập nhật và áp dụng chúng sau khi khởi động lại. Xin lưu ý rằng bạn có thể mất cài đặt trong quá trình này.
 
 Nhật ký thay đổi:
 - {0}
@@ -242,10 +242,10 @@ Cảnh báo: Trong quá trình cập nhật, thư mục "Update" và tệp "Upda
     <value>Dừng tác vụ gỡ cài đặt hiện tại</value>
   </data>
   <data name="MessageBoxes_TaskStopConfirmation_Message" xml:space="preserve">
-    <value>Bạn có chắc là muốn dừng tác vụ hiện đang chạy không?</value>
+    <value>Bạn có chắc là muốn dừng tác vụ hiện đang thực thi chứ?</value>
   </data>
   <data name="MessageBoxes_TaskStopConfirmation_Details" xml:space="preserve">
-    <value>Nếu bạn dừng tác vụ giữa chừng thì những thay đổi sẽ không được hoàn tác. Trình gỡ cài đặt hiện đang chạy sẽ không dừng và sẽ đợi tác vụ hoàn tất.</value>
+    <value>Dừng tác vụ trước khi hoàn thành sẽ không hoàn tác bất kỳ thay đổi nào đã thực hiện. Trình gỡ cài đặt đang thực thi sẽ không bị dừng lại, tác vụ sẽ đợi nó hoàn tất.</value>
   </data>
   <data name="MessageBoxes_Title_Create_restore_point" xml:space="preserve">
     <value>Tạo điểm khôi phục</value>
@@ -265,28 +265,28 @@ Cảnh báo: Trong quá trình cập nhật, thư mục "Update" và tệp "Upda
     <value>Tiến trình gỡ cài đặt</value>
   </data>
   <data name="MessageBoxes_CanWalkAwayInfo_Message" xml:space="preserve">
-    <value>Bây giờ bạn có thể rời khỏi máy tính của mình</value>
+    <value>Bạn có thể rời khỏi máy tính của mình ngay bây giờ</value>
   </data>
   <data name="MessageBoxes_CanWalkAwayInfo_Details" xml:space="preserve">
-    <value>Phần còn lại của trình gỡ cài đặt có thể được hoàn thành mà không cần sự can thiệp của người dùng. Bạn nên kiểm tra thường xuyên đề phòng trường hợp trình gỡ cài đặt gặp sự cố.</value>
+    <value>Các trình gỡ cài đặt còn lại có thể hoàn thành mà không cần sự can thiệp của người dùng. Tuy nhiên, bạn vẫn nên kiểm tra định kỳ đề phòng trường hợp một trong số các trình gỡ cài đặt bị lỗi.</value>
   </data>
   <data name="MessageBoxes_Title_Junk_Leftover_removal" xml:space="preserve">
     <value>Loại bỏ rác/phần còn sót lại</value>
   </data>
   <data name="MessageBoxes_ConfirmLowConfidenceQuestion_Message" xml:space="preserve">
-    <value>Bạn có thực sự muốn sửa các mục có độ tin cậy thấp không?</value>
+    <value>Bạn có thực sự muốn thay đổi các mục có độ tin cậy thấp chứ?</value>
   </data>
   <data name="MessageBoxes_ConfirmLowConfidenceQuestion_Details" xml:space="preserve">
     <value>Việc xóa các mục được đánh dấu có độ tin cậy thấp có thể rất nguy hiểm! Bạn nên xác minh rằng mọi mục đều an toàn để xóa.</value>
   </data>
   <data name="MessageBoxes_DeleteRegKeysConfirmation_Title" xml:space="preserve">
-    <value>Xoá các khoá khỏi thanh ghi</value>
+    <value>Xoá các khoá khỏi registry</value>
   </data>
   <data name="MessageBoxes_DeleteRegKeysConfirmation_Message" xml:space="preserve">
-    <value>Bạn có chắc là muốn xóa mục trình gỡ cài đặt đã chọn không?</value>
+    <value>Bạn có chắc là muốn xóa mục trình gỡ cài đặt đã chọn chứ?</value>
   </data>
   <data name="MessageBoxes_DeleteRegKeysConfirmation_Details" xml:space="preserve">
-    <value>Các mục sau sẽ bị xóa khỏi sổ đăng ký và sẽ biến mất khỏi danh sách của trình gỡ cài đặt nhưng sẽ không được gỡ cài đặt.
+    <value>Các mục sau sẽ bị xóa khỏi registry và sẽ biến mất khỏi danh sách của trình gỡ cài đặt nhưng sẽ không được nó gỡ cài đặt.
 
 {0}</value>
   </data>
@@ -300,7 +300,7 @@ Cảnh báo: Trong quá trình cập nhật, thư mục "Update" và tệp "Upda
     <value>Nếu lỗi vẫn còn, hãy thử lưu vào một thư mục khác, chẳng hạn như "Desktop".</value>
   </data>
   <data name="MessageBoxes_GetSystemRestoreDescription" xml:space="preserve">
-    <value>BCUninstaller đang gỡ cài đặt (các) ứng dụng {0}</value>
+    <value>BCUninstaller đang gỡ cài đặt {0} ứng dụng</value>
     <comment>0 is the uninstaller count</comment>
   </data>
   <data name="MessageBoxes_Title_Rename_uninstaller" xml:space="preserve">
@@ -315,10 +315,10 @@ Cảnh báo: Trong quá trình cập nhật, thư mục "Update" và tệp "Upda
     <comment>0 is list of characters separated by spaces</comment>
   </data>
   <data name="MessageBoxes_LookForJunkQuestion_Message" xml:space="preserve">
-    <value>Bạn muốn tìm phần còn sót lại của (các) lần gỡ cài đặt mà bạn đã thực hiện?</value>
+    <value>Bạn muốn kiểm tra các phần còn sót lại của (các) lần gỡ cài đặt mà bạn đã thực hiện chứ?</value>
   </data>
   <data name="MessageBoxes_LookForJunkQuestion_Details" xml:space="preserve">
-    <value>Xin lưu ý rằng tính năng này chỉ dành cho những người dùng thành thạo hiểu cách hoạt động của nó. Không cần thiết phải xóa các tệp này và chúng sẽ không ảnh hưởng đến hiệu suất hệ thống theo bất kỳ cách nào.</value>
+    <value>Cần lưu ý rằng tính năng này chỉ dành cho người dùng chuyên sâu, hiểu rõ cách hoạt động của nó. Không cần thiết phải xóa các tệp này và chúng không ảnh hưởng đáng kể đến hiệu suất hệ thống.</value>
   </data>
   <data name="MessageBoxes_NoJunkFoundInfo_Message" xml:space="preserve">
     <value>Không tìm thấy bất kỳ phần còn sót lại nào</value>
@@ -336,7 +336,7 @@ Cảnh báo: Trong quá trình cập nhật, thư mục "Update" và tệp "Upda
     <value>Mở thư mục</value>
   </data>
   <data name="MessageBoxes_OpenDirectoriesMessageBox_OpenMultiple" xml:space="preserve">
-    <value>Thao tác này sẽ mở {0} thư mục cùng một lúc, bạn có chăc là muốn tiếp tục không?</value>
+    <value>Thao tác này sẽ mở {0} thư mục cùng một lúc, bạn có chắc là muốn tiếp tục chứ?</value>
     <comment>0 is number of directories to open
 </comment>
   </data>
@@ -350,28 +350,29 @@ Cảnh báo: Trong quá trình cập nhật, thư mục "Update" và tệp "Upda
     <value>Gỡ cài đặt BCUninstaller</value>
   </data>
   <data name="MessageBoxes_SelfUninstallQuestion_Message" xml:space="preserve">
-    <value>Bạn có chắc là muốn gỡ cài đặt BCUninstaller không?</value>
+    <value>Bạn có chắc là muốn gỡ cài đặt BCUninstaller chứ?</value>
   </data>
   <data name="MessageBoxes_SelfUninstallQuestion_Details" xml:space="preserve">
-    <value>Tôi rất tiếc khi bạn rời đi! Nếu bạn có một hoặc hai phút, vui lòng cho biết lý do tại sao bạn gỡ cài đặt BCU trên trang web của tôi (http://klocmansoftware.weebly.com/). Tôi sẽ cố gắng hết sức để khắc phục mọi vấn đề những vấn đề chính đáng.</value>
+    <value>Tôi rất tiếc vì bạn đã gỡ bỏ BCU! Nếu bạn có một vài phút, hãy cho tôi biết lý do tại sao bạn gỡ cài đặt BCU trên trang web của tôi (http://klocmansoftware.weebly.com/). Tôi sẽ cố gắng hết sức để khắc phục bất kỳ sự cố chính đáng nào.</value>
   </data>
   <data name="MessageBoxes_SysRestoreBeginQuestion_Message" xml:space="preserve">
-    <value>Bạn có muốn tạo điểm khôi phục trước khi tiếp tục không?</value>
+    <value>Bạn có muốn tạo điểm khôi phục trước khi tiếp tục chứ?</value>
   </data>
   <data name="MessageBoxes_SysRestoreBeginQuestion_Details" xml:space="preserve">
-    <value>Nếu bạn không chắc chắn liệu ứng dụng bạn muốn gỡ cài đặt có quan trọng hay cần thiết cho sự ổn định của hệ thống hay không, chúng tôi khuyên bạn nên tạo điểm khôi phục. Nếu có sự cố xảy ra sau quy trình, bạn có thể sử dụng Khôi phục Hệ thống để khôi phục các thay đổi của mình.</value>
+    <value>Nếu bạn không chắc chắn rằng các ứng dụng bạn đang gỡ cài đặt có quan trọng hoặc cần thiết cho sự ổn định của hệ thống hay không, thì việc tạo điểm khôi phục hệ thống là điều được khuyến khích.
+Nếu bất kỳ vấn đề gì xảy ra sau quá trình gỡ cài đặt, bạn có thể sử dụng tính năng Khôi phục Hệ thống để hoàn tác các thay đổi.</value>
   </data>
   <data name="MessageBoxes_SearchOnlineError_Message" xml:space="preserve">
     <value>Đã xảy ra lỗi khi mở trang tìm kiếm.</value>
   </data>
   <data name="MessageBoxes_Title_Save_Uninstall_List" xml:space="preserve">
-    <value>Lưu Danh sách Gỡ cài đặt</value>
+    <value>Lưu danh sách bộ lọc gỡ cài đặt</value>
   </data>
   <data name="MessageBoxes_SaveUninstallListError_Message" xml:space="preserve">
     <value>Lưu danh sách vào tệp không thành công</value>
   </data>
   <data name="MessageBoxes_ResetSettingsConfirmation_Message" xml:space="preserve">
-    <value>Bạn có chắc là muốn đặt lại tất cả cài đặt ứng dụng không?</value>
+    <value>Bạn có chắc là muốn khôi phục lại tất cả cài đặt ứng dụng chứ?</value>
   </data>
   <data name="MessageBoxes_QuietUninstallersNotAvailableQuestion_Message" xml:space="preserve">
     <value>Một số ứng dụng không thể được gỡ cài đặt âm thầm.</value>
@@ -386,22 +387,22 @@ Cảnh báo: Trong quá trình cập nhật, thư mục "Update" và tệp "Upda
     <value>Đã xảy ra lỗi khi mở URL</value>
   </data>
   <data name="MessageBoxes_OpenUninstallListQuestion_Message" xml:space="preserve">
-    <value>Bạn có muốn giữ lại lựa chọn hiện tại không?</value>
+    <value>Bạn có muốn giữ lại lựa chọn hiện tại chứ?</value>
   </data>
   <data name="MessageBoxes_OpenDirectoryError_Message" xml:space="preserve">
     <value>Đã xảy ra lỗi khi mở thư mục</value>
   </data>
   <data name="MessageBoxes_OpenUninstallListError_Message" xml:space="preserve">
-    <value>Nạp các tập tin đã chọn không thành công</value>
+    <value>Xử lý các tập tin đã chọn không thành công</value>
   </data>
   <data name="MessageBoxes_NoUninstallersSelectedInfo_Message" xml:space="preserve">
     <value>Không có gì để gỡ cài đặt vì không có trình gỡ cài đặt nào được chọn.</value>
   </data>
   <data name="MessageBoxes_NoUninstallersSelectedInfo_Title" xml:space="preserve">
-    <value>Chạy trình gỡ cài đặt</value>
+    <value>Khởi chạy trình gỡ cài đặt</value>
   </data>
   <data name="MessageBoxes_NoUninstallersSelectedInfo_Details" xml:space="preserve">
-    <value>Để gỡ cài đặt ứng dụng, trước tiên bạn phải chọn ứng dụng đó từ chế độ xem danh sách. Nếu bạn đang sử dụng hộp kiểm, hãy đảm bảo chúng được chọn.</value>
+    <value>Để gỡ cài đặt ứng dụng, trước tiên bạn phải chọn ứng dụng đó từ chế độ xem danh sách. Nếu có các hộp kiểm, hãy nhớ tích vào chúng.</value>
   </data>
   <data name="MessageBoxes_OpenUninstallListQuestion_Details" xml:space="preserve">
     <value>Nếu bạn chọn giữ lựa chọn hiện tại, nó sẽ được hợp nhất vào (các) danh sách đã mở.</value>
@@ -422,7 +423,7 @@ Cảnh báo: Trong quá trình cập nhật, thư mục "Update" và tệp "Upda
     <value>Các mục bị ảnh hưởng:
 {0}
 
-Để thay đổi các mục này, bạn phải tắt bảo vệ trình gỡ cài đặt từ cài đặt ở thanh bên. Nếu muốn, bạn có thể xóa những mục này khỏi tác vụ và tiếp tục với các mục khác.</value>
+Để thay đổi các mục này, bạn phải tắt bảo vệ trình gỡ cài đặt từ cài đặt ở thanh bên. Bạn có thể xóa những mục này khỏi tác vụ và tiếp tục với các mục khác nếu muốn.</value>
     <comment>0 names of protected uninstallers</comment>
   </data>
   <data name="MessageBoxes_ProtectedItemError_Details" xml:space="preserve">
@@ -435,23 +436,23 @@ Cảnh báo: Trong quá trình cập nhật, thư mục "Update" và tệp "Upda
     <value>Trình gỡ cài đặt âm thầm bị thiếu các mục sau:
 {0}
 
-Bạn có muốn sử dụng trình gỡ cài đặt "ồn ào" cho những mục này, hay bạn muốn loại bỏ chúng khỏi tác vụ?</value>
+Bạn có muốn sử dụng trình gỡ cài đặt gốc cho những mục này, hay bạn muốn loại bỏ chúng khỏi tác vụ?</value>
     <comment>0 is names of non-quiet uninstallers</comment>
   </data>
   <data name="MessageBoxes_Title_Quiet_uninstall" xml:space="preserve">
     <value>Gỡ cài đặt âm thầm</value>
   </data>
   <data name="MessageBoxes_Title_Restore_default_settings" xml:space="preserve">
-    <value>Khôi phục các cài đặt mặc định</value>
+    <value>Khôi phục các cài đặt gốc</value>
   </data>
   <data name="MessageBoxes_ResetSettingsConfirmation_Details" xml:space="preserve">
-    <value>Tất cả cài đặt sẽ bị mất vĩnh viễn. BCUninstaller phải được khởi động lại để hoàn thành thao tác này.</value>
+    <value>Tất cả các cài đặt của bạn sẽ bị mất vĩnh viễn. BCUninstaller cần phải khởi động lại để hoàn thành hành động này.</value>
   </data>
   <data name="MessageBoxes_Title_Open_Uninstall_List" xml:space="preserve">
-    <value>Mở Danh sách Gỡ cài đặt</value>
+    <value>Mở danh sách gỡ cài đặt</value>
   </data>
   <data name="MessageBoxes_SysRestoreContinueAfterError_Details" xml:space="preserve">
-    <value>KHÔNG CÓ ĐIỂM KHÔI PHỤC NÀO ĐƯỢC TẠO nên không thể khôi phục các thay đổi! Bạn vẫn muốn tiếp tục gỡ cài đặt không?</value>
+    <value>KHÔNG CÓ ĐIỂM KHÔI PHỤC NÀO ĐƯỢC TẠO, nên không thể hoàn tác các thay đổi! Bạn vẫn muốn tiếp tục gỡ cài đặt chứ?</value>
   </data>
   <data name="MainWindow_Rename_Description" xml:space="preserve">
     <value>Đang đổi tên "{0}"</value>
@@ -474,7 +475,7 @@ Bạn có muốn sử dụng trình gỡ cài đặt "ồn ào" cho những mụ
     <value>Lỗi</value>
   </data>
   <data name="PropertiesWindow_Table_ErrorDoesntExist" xml:space="preserve">
-    <value>Tập tin không tồn tại.</value>
+    <value>Tệp tin không tồn tại.</value>
   </data>
   <data name="PropertiesWindow_Table_ErrorMsi" xml:space="preserve">
     <value>Không có gì được hiển thị. Ứng dụng này được gỡ cài đặt bằng Trình gỡ cài đặt Windows (MsiExec).</value>
@@ -495,16 +496,16 @@ Bạn có muốn sử dụng trình gỡ cài đặt "ồn ào" cho những mụ
     <value>Thiếu GUID</value>
   </data>
   <data name="JunkRemove_SelectionBoxText" xml:space="preserve">
-    <value>Chọn các mục bên dưới...</value>
+    <value>Lựa chọn...</value>
   </data>
   <data name="Error_FileNotFound" xml:space="preserve">
-    <value>Không tìm thấy tập tin.</value>
+    <value>Không tìm thấy tệp tin.</value>
   </data>
   <data name="LoadingDialogTitlePostUninstallCommands" xml:space="preserve">
-    <value>Đang các chạy lệnh sau khi gỡ cài đặt...</value>
+    <value>Đang các thực thi các câu lệnh sau khi gỡ cài đặt (post-uninstall)...</value>
   </data>
   <data name="LoadingDialogTitlePreUninstallCommands" xml:space="preserve">
-    <value>Đang chạy lệnh trước khi gỡ cài đặt...</value>
+    <value>Đang thực thi các câu lệnh trước khi gỡ cài đặt (pre-uninstall)...</value>
   </data>
   <data name="MainWindow_Statusbar_StatusReady" xml:space="preserve">
     <value>Sẵn sàng</value>
@@ -519,7 +520,7 @@ Bạn có muốn sử dụng trình gỡ cài đặt "ồn ào" cho những mụ
     <comment>{0} is a number of all uninstallers, {1} is a long file size (123 Megabytes)</comment>
   </data>
   <data name="MessageBoxes_ExternalCommandFailed_Message" xml:space="preserve">
-    <value>Không thực hiện được lệnh sau:
+    <value>Không thực hiện được câu lệnh sau:
 {0}</value>
     <comment>{0} is a command line (c:\example.exe /help)</comment>
   </data>
@@ -534,7 +535,7 @@ Bạn có muốn sử dụng trình gỡ cài đặt "ồn ào" cho những mụ
     <value>Một số cài đặt không có hiệu lực cho đến khi bạn khởi động lại ứng dụng.</value>
   </data>
   <data name="MessageBoxes_RestartNeededForSettingChangeQuestion_Message" xml:space="preserve">
-    <value>Bạn có muốn khởi động lại BCU để áp dụng các cài đặt mới không?</value>
+    <value>Bạn có muốn khởi động lại BCU để áp dụng các cài đặt mới chứ?</value>
   </data>
   <data name="MessageBoxes_RestartNeededForSettingChangeQuestion_Title" xml:space="preserve">
     <value>Thay đổi cài đặt ứng dụng</value>
@@ -543,7 +544,7 @@ Bạn có muốn sử dụng trình gỡ cài đặt "ồn ào" cho những mụ
     <value>Không có chứng chỉ</value>
   </data>
   <data name="MainWindow_Statusbar_ProcessingUninstallers" xml:space="preserve">
-    <value>Đang xử lý các ứng dụng được phát hiện, còn lại {0}...</value>
+    <value>Đang xử lý các ứng dụng được phát hiện, còn lại {0} ứng dụng...</value>
     <comment>{1} = how many application uninstallers still need to be processed</comment>
   </data>
   <data name="MessageBoxes_TaskSkip_Details" xml:space="preserve">
@@ -552,13 +553,13 @@ Bạn có muốn sử dụng trình gỡ cài đặt "ồn ào" cho những mụ
 Ngoài ra, bạn có thể bỏ qua việc chờ quá trình này. Việc bỏ qua sẽ cho phép trình gỡ cài đặt tiếp tục hoạt động trong khi tác vụ chuyển sang mục tiếp theo. Hãy nhớ rằng một số trình gỡ cài đặt có thể không chạy cho đến khi quá trình bị bỏ qua kết thúc.</value>
   </data>
   <data name="MessageBoxes_TaskSkip_Message" xml:space="preserve">
-    <value>Bạn muốn bỏ qua trạng thái chờ của trình gỡ cài đặt hiện đang chạy không?</value>
+    <value>Bạn muốn bỏ qua trạng thái chờ của trình gỡ cài đặt hiện đang thực thi chứ?</value>
   </data>
   <data name="MessageBoxes_TaskSkip_Title" xml:space="preserve">
-    <value>Bỏ qua tác vụ hiện đang chạy</value>
+    <value>Bỏ qua tác vụ hiện đang thực thi</value>
   </data>
   <data name="MessageBoxes_UninstallAlreadyRunning_Message" xml:space="preserve">
-    <value>Một tác vụ gỡ cài đặt khác đang chạy sẽ bỏ qua tác vụ hiện đang chạy. Vui lòng đợi cho đến khi nó hoàn tất và thử lại.</value>
+    <value>Một tác vụ gỡ cài đặt khác đang thực thi. Vui lòng đợi cho đến khi nó hoàn tất và thử lại.</value>
   </data>
   <data name="JunkRemove_Details_Message" xml:space="preserve">
     <value>Đánh giá: {0}
@@ -577,16 +578,16 @@ The lists are separated by a single newline.</comment>
     <value>Chi tiết đánh giá</value>
   </data>
   <data name="PropertiesWindow_Table_ErrorMissingRegistry" xml:space="preserve">
-    <value>Ứng dụng này không có bất kỳ mục thanh ghi hợp lệ nào.</value>
+    <value>Ứng dụng này không có bất kỳ mục registry hợp lệ nào.</value>
   </data>
   <data name="PropertiesWindow_Table_ErrorMissingUninstaller" xml:space="preserve">
-    <value>Ứng dụng này không có trình gỡ cài đặt hợp lệ.</value>
+    <value>Ứng dụng này không có trình gỡ cài đặt hợp lệ nào.</value>
   </data>
   <data name="LoadingDialogTitleLoadingWindowsFeatures" xml:space="preserve">
     <value>Đang nạp Windows Features...</value>
   </data>
   <data name="MainWindow_Statusbar_RefreshingStartup" xml:space="preserve">
-    <value>Đang làm mới thông tin khởi động...</value>
+    <value>Đang làm mới thông tin khởi động cùng hệ thống...</value>
     <comment>Shown when refreshing autostart information of the uninstallers</comment>
   </data>
   <data name="MessageBoxes_OpenDirectories_NoDirsToOpen" xml:space="preserve">
@@ -600,7 +601,7 @@ The lists are separated by a single newline.</comment>
     <value>Đánh giá không có sẵn</value>
   </data>
   <data name="MessageBoxes_RatingsDisabled_Message" xml:space="preserve">
-    <value>Trước tiên, bạn cần bật đánh giá từ cài đặt.</value>
+    <value>Trước tiên, bạn cần bật tính năng đánh giá từ cài đặt.</value>
   </data>
   <data name="MessageBoxes_RatingUnavailable_Message" xml:space="preserve">
     <value>Bạn không thể đánh giá các ứng dụng không được cài đặt đúngc cách.</value>
@@ -622,7 +623,7 @@ Bạn có thể thử tắt tính năng phát hiện xung đột trong cài đ�
     <value>Buộc gỡ cài đặt</value>
   </data>
   <data name="MessageBoxes_ForceRunUninstallFailedError_Header" xml:space="preserve">
-    <value>Một số trình gỡ cài đặt không chạy được.</value>
+    <value>Một số trình gỡ cài đặt không thực thi được.</value>
   </data>
   <data name="MessageBoxes_Net4Missing_Title" xml:space="preserve">
     <value>Không tìm thấy .NET Framework v4.0</value>
@@ -631,16 +632,16 @@ Bạn có thể thử tắt tính năng phát hiện xung đột trong cài đ�
     <value>Một số tính năng sẽ bị tắt do không tìm thấy .NET Framework v4.0.</value>
   </data>
   <data name="MessageBoxes_Net4Missing_Details" xml:space="preserve">
-    <value>v4.0 Framework là tùy chọn nhưng được khuyến nghị. Các tính năng phụ thuộc vào framework sẽ bị tắt cho đến khi bạn cài đặt chúng.</value>
+    <value>.NET framework v4.0 là tùy chọn nhưng được khuyến nghị. Các tính năng phụ thuộc vào framework sẽ bị tắt cho đến khi bạn cài đặt chúng.</value>
   </data>
   <data name="MessageBoxes_AskToRetryFailedQuietAsLoud_Title" xml:space="preserve">
     <value>Một số trình gỡ cài đặt không thành công</value>
   </data>
   <data name="MessageBoxes_AskToRetryFailedQuietAsLoud_Header" xml:space="preserve">
-    <value>Trình gỡ cài đặt ồn ào không thành công, tại sao bạn không thử chạy trình gỡ cài đặt âm thầm?</value>
+    <value>Trình gỡ cài đặt không thành công, tại sao bạn không thử chạy trình gỡ cài đặt âm thầm?</value>
   </data>
   <data name="MessageBoxes_AskToRetryFailedQuietAsLoud_Details" xml:space="preserve">
-    <value>Trình gỡ cài đặt bên dưới sẽ khởi động lại theo chế độ ồn ào: </value>
+    <value>Trình gỡ cài đặt bên dưới sẽ khởi động lại trình gỡ cài đặt gốc: </value>
   </data>
   <data name="UninstallFromDirectory_ScanningTitle" xml:space="preserve">
     <value>Đang quét thư mục được chỉ định...</value>
@@ -655,13 +656,13 @@ Bạn có thể thử tắt tính năng phát hiện xung đột trong cài đ�
     <value>Không tìm thấy ứng dụng nào trong thư mục được chỉ định</value>
   </data>
   <data name="MessageBoxes_UninstallFromDirectoryNothingFound_Details" xml:space="preserve">
-    <value>Hãy chắc rằng thư mục đã chọn có chính xác không và tệp thực thi của ứng dụng vẫn còn.</value>
+    <value>Hãy chắc rằng thư mục đã chọn có chính xác và tệp thực thi của ứng dụng vẫn còn.</value>
   </data>
   <data name="MessageBoxes_UninstallFromDirectoryUninstallerFound_Message" xml:space="preserve">
     <value>Đã tìm thấy trình gỡ cài đặt cho {0}</value>
   </data>
   <data name="MessageBoxes_UninstallFromDirectoryUninstallerFound_Details" xml:space="preserve">
-    <value>Bạn có muốn chạy trình gỡ cài đặt này không?</value>
+    <value>Bạn có muốn chạy trình gỡ cài đặt này chứ?</value>
   </data>
   <data name="Error_SaveSettingsFailed" xml:space="preserve">
     <value>Lưu cài đặt không thành công</value>
@@ -673,10 +674,10 @@ Bạn có thể thử tắt tính năng phát hiện xung đột trong cài đ�
     <value>Đang nạp biểu tượng</value>
   </data>
   <data name="TargetWindow_NoFilesSelected_Title" xml:space="preserve">
-    <value>Tìm kiếm một ứng dụng</value>
+    <value>Tìm kiếm ứng dụng</value>
   </data>
   <data name="TargetWindow_NoFilesSelected_Message" xml:space="preserve">
-    <value>Không có tập tin hoặc thư mục hợp lệ nào được chọn. Đảm bảo rằng bạn có quyền làm như vậy và nó không bị đánh dấu là tệp hệ thống.</value>
+    <value>Không có tệp tin hoặc thư mục hợp lệ nào được chọn. Đảm bảo rằng bạn có quyền truy cập và nó không bị đánh dấu là tệp hệ thống.</value>
   </data>
   <data name="Uninstaller_GetApplicationsFromDirectories_NothingFound_Title" xml:space="preserve">
     <value>Tìm kiếm ứng dụng</value>
@@ -691,13 +692,13 @@ Bạn có thể thử tắt tính năng phát hiện xung đột trong cài đ�
     <value>Không thể thay đổi ứng dụng đã chọn</value>
   </data>
   <data name="MessageBoxes_ModifyCommandMissing_Details" xml:space="preserve">
-    <value>Không có lệnh sửa đổi nào được chỉ định cho ứng dụng đã chọn. Bạn có thể cần phải gỡ cài đặt và cài đặt lại để thay đổi cài đặt cài đặt.</value>
+    <value>Không có câu lệnh sửa đổi nào được chỉ định cho ứng dụng đã chọn. Bạn có thể cần phải gỡ cài đặt và cài đặt lại để thay đổi cài đặt cài đặt.</value>
   </data>
   <data name="MessageBoxes_AskToSaveUninstallList_Title" xml:space="preserve">
     <value>Lưu danh sách gỡ cài đặt</value>
   </data>
   <data name="MessageBoxes_AskToSaveUninstallList_Message" xml:space="preserve">
-    <value>Bạn có muốn lưu các thay đổi vào danh sách gỡ cài đặt đang mở không?</value>
+    <value>Bạn có muốn lưu các thay đổi vào danh sách gỡ cài đặt đang mở chứ?</value>
   </data>
   <data name="MessageBoxes_AskToSaveUninstallList_Details" xml:space="preserve">
     <value>Có những thay đổi chưa được lưu trong danh sách gỡ cài đặt đang mở và sẽ bị mất khi đóng.</value>
@@ -706,7 +707,7 @@ Bạn có thể thử tắt tính năng phát hiện xung đột trong cài đ�
     <value>Chọn thư mục chứa ứng dụng mà bạn muốn gỡ cài đặt.</value>
   </data>
   <data name="JunkRemoveWindow_SelectBackupDirectoryTitle" xml:space="preserve">
-    <value>Chọn một vị trí để lưu bản sao lưu. Một thư mục mới sẽ được tạo.</value>
+    <value>Chọn nơi để lưu bản sao lưu. Một thư mục mới sẽ được tạo.</value>
   </data>
   <data name="NewsPopup_UpdatedTitle" xml:space="preserve">
     <value>BCU đã được cập nhật lên v{0}!</value>
@@ -715,7 +716,7 @@ Bạn có thể thử tắt tính năng phát hiện xung đột trong cài đ�
     <value>Chào mừng bạn đến với phiên bản {0} của BCU!</value>
   </data>
   <data name="UninstallProgressWindow_StatusPuttingToSleepInSeconds" xml:space="preserve">
-    <value>Đặt PC ở chế độ ngủ trong {0} giây. Bỏ chọn hộp kiểm để hủy.</value>
+    <value>Thiếp lập PC ở chế độ ngủ trong {0} giây. Tích vào hộp kiểm để hủy.</value>
   </data>
   <data name="UninstallerListDoubleClickAction_DoNothing" xml:space="preserve">
     <value>Không làm gì cả</value>
@@ -742,10 +743,10 @@ Bạn có thể thử tắt tính năng phát hiện xung đột trong cài đ�
     <value>Phần mở rộng</value>
   </data>
   <data name="LocalizedX509Certificate2_FriendlyName" xml:space="preserve">
-    <value>Tên Dễ hiểu</value>
+    <value>Tên dễ hiểu</value>
   </data>
   <data name="LocalizedX509Certificate2_IssuerName" xml:space="preserve">
-    <value>Tên của Thực thể chứng thực</value>
+    <value>Tên của thực thể chứng thực</value>
   </data>
   <data name="LocalizedX509Certificate2_NotAfter" xml:space="preserve">
     <value>Không sau ngày</value>
@@ -766,7 +767,7 @@ Bạn có thể thử tắt tính năng phát hiện xung đột trong cài đ�
     <value>Dữ liệu thô</value>
   </data>
   <data name="LocalizedX509Certificate2_SerialNumber" xml:space="preserve">
-    <value>Số Serial</value>
+    <value>Số Sêri</value>
   </data>
   <data name="LocalizedX509Certificate2_SubjectName" xml:space="preserve">
     <value>Tên chủ thể</value>
@@ -775,9 +776,9 @@ Bạn có thể thử tắt tính năng phát hiện xung đột trong cài đ�
     <value>Phiên bản</value>
   </data>
   <data name="LocalizedX509Certificate2_Thumbprint" xml:space="preserve">
-    <value>Thumbprint</value>
+    <value>Vân tay khoá công khai</value>
   </data>
   <data name="LocalizedX509Certificate2_SignatureAlgorithm" xml:space="preserve">
-    <value>Thuật toán Chữ ký</value>
+    <value>Thuật toán chữ ký</value>
   </data>
 </root>

--- a/source/NBug_custom/Core/UI/WinForms/Full.vi.resx
+++ b/source/NBug_custom/Core/UI/WinForms/Full.vi.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="warningLabel.Text" xml:space="preserve">
-    <value>Ứng dụng đã gặp sự cố và bây giờ nó sẽ bị đóng. Nếu bạn nhấp vào "Thoát", ứng dụng sẽ đóng ngay lập tức. Nếu bạn nhấp vào "Gửi và Thoát", ứng dụng sẽ đóng và một báo cáo lỗi sẽ được gửi.</value>
+    <value>Ứng dụng đã gặp sự cố và sẽ tự động đóng. Nếu bạn nhấp chuột vào nút "Thoát", ứng dụng sẽ đóng ngay lập tức. Nếu bạn nhấp chuột vào nút "Gửi và Thoát", ứng dụng sẽ đóng và đồng thời gửi một báo cáo lỗi về sự cố này.</value>
   </data>
 </root>

--- a/source/NBug_custom/Properties/Localization.vi.resx
+++ b/source/NBug_custom/Properties/Localization.vi.resx
@@ -118,15 +118,15 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="UI_Console_Full_Message" xml:space="preserve">
-    <value>Một ngoại lệ không thể giải quyết đã xãy ra. Đang đóng ứng dụng.</value>
+    <value>Lỗi ngoại lệ chưa được xử lý. Đang đóng ứng dụng.</value>
     <comment>Unhandled exception occurred. Closing application.</comment>
   </data>
   <data name="UI_Console_Minimal_Message" xml:space="preserve">
-    <value>Một ngoại lệ không thể giải quyết đã xãy ra. Đang đóng ứng dụng.</value>
+    <value>Lỗi ngoại lệ chưa được xử lý. Đang đóng ứng dụng.</value>
     <comment>Unhandled exception occurred. Closing application.</comment>
   </data>
   <data name="UI_Console_Normal_Message" xml:space="preserve">
-    <value>Một ngoại lệ không thể giải quyết đã xãy ra. Đang đóng ứng dụng.</value>
+    <value>Lỗi ngoại lệ chưa được xử lý. Đang đóng ứng dụng.</value>
     <comment>Unhandled exception occurred. Closing application.</comment>
   </data>
   <data name="UI_Dialog_Full_Exception_Tab" xml:space="preserve">
@@ -138,11 +138,11 @@
     <comment>General</comment>
   </data>
   <data name="UI_Dialog_Full_How_to_Reproduce_the_Error_Notification" xml:space="preserve">
-    <value>Vui lòng thêm một mô tả ngắn gọn để tái hiện lỗi: </value>
+    <value>Vui lòng cung cấp một mô tả ngắn gọn đề tái hiện lỗi: </value>
     <comment>Please add a brief description of how we can reproduce the error:</comment>
   </data>
   <data name="UI_Dialog_Full_Message" xml:space="preserve">
-    <value>Ứng dụng đã gặp sự cố và bây giờ nó sẽ bị đóng. Nếu bạn nhấp vào "Thoát", ứng dụng sẽ đóng ngay lập tức. Nếu bạn nhấp vào "Gửi và Thoát", ứng dụng sẽ đóng và một báo cáo lỗi sẽ được gửi.</value>
+    <value>Ứng dụng đã gặp sự cố và sẽ tự động đóng. Nếu bạn nhấp chuột vào nút "Thoát", ứng dụng sẽ đóng ngay lập tức. Nếu bạn nhấp chuột vào nút "Gửi và Thoát", ứng dụng sẽ đóng và đồng thời gửi một báo cáo lỗi về sự cố này.</value>
     <comment>The application has crashed and it will now be dismissed. If you click Quit, the application will close immediately. If you click Send and Quit, the application will close and a bug report will be send.</comment>
   </data>
   <data name="UI_Dialog_Full_Quit_Button" xml:space="preserve">
@@ -162,7 +162,8 @@
     <comment>Error</comment>
   </data>
   <data name="UI_Dialog_Minimal_Message" xml:space="preserve">
-    <value>Ứng dụng đã gặp sự cố và bây giờ nó sẽ bị đóng. Đã gửi báo cáo lỗi cho nhà phát triển. Chúng tôi xin lỗi vì sự bất tiện này.</value>
+    <value>Ứng dụng đã gặp sự cố và sẽ bị đóng lại.
+Một báo cáo lỗi đã được gửi đến nhà phát triển. Chúng tôi chân thành xin lỗi vì sự bất tiện này.</value>
     <comment>The application has crashed and it will now be dismissed.
 A bug report has been sent to the developers. We apologize for the inconvenience.</comment>
   </data>
@@ -171,11 +172,11 @@ A bug report has been sent to the developers. We apologize for the inconvenience
     <comment>Error</comment>
   </data>
   <data name="UI_Dialog_Normal_Continue_Button" xml:space="preserve">
-    <value>&amp;Tiếp tục</value>
+    <value>Tiế&amp;p tục</value>
     <comment>&amp;Continue</comment>
   </data>
   <data name="UI_Dialog_Normal_Message" xml:space="preserve">
-    <value>Một ngoại lệ chưa được xử lý đã xảy ra trong ứng dụng của bạn. Nếu bạn bấm vào "Tiếp tục", ứng dụng sẽ cố gắng bỏ qua lỗi này và tiếp tục. Nếu bạn nhấp vào "Thoát", ứng dụng sẽ đóng ngay lập tức.</value>
+    <value>Đã xảy ra một lỗi ngoại lệ chưa được xử lý trong ứng dụng. Nếu bạn chọn "Tiếp tục", ứng dụng sẽ bỏ qua lỗi này và cố gắng tiếp tục chạy. Nếu bạn chọn "Thoát", ứng dụng sẽ đóng ngay lập tức.</value>
     <comment>.</comment>
   </data>
   <data name="UI_Dialog_Normal_Quit_Button" xml:space="preserve">

--- a/source/UninstallTools/Controls/UninstallListEditor.vi.resx
+++ b/source/UninstallTools/Controls/UninstallListEditor.vi.resx
@@ -166,9 +166,9 @@
     <value>Trình chỉnh sửa điều kiện</value>
   </data>
   <data name="openFileDialog.Filter" xml:space="preserve">
-    <value>Danh sách gỡ cài đặt (*.bcul)|*.bcul|Tất cả tệp|*.*</value>
+    <value>Danh sách bộ lọc gỡ cài đặt (*.bcul)|*.bcul|Tất cả tệp|*.*</value>
   </data>
   <data name="openFileDialog.Title" xml:space="preserve">
-    <value>Nạp Danh sách Gỡ cài đặt</value>
+    <value>Làm mới danh sách bộ lọc gỡ cài đặt</value>
   </data>
 </root>

--- a/source/UninstallTools/Dialogs/StartupManagerWindow.vi.resx
+++ b/source/UninstallTools/Dialogs/StartupManagerWindow.vi.resx
@@ -121,7 +121,7 @@
     <value>Hiển thị tất cả</value>
   </data>
   <data name="comboBoxFilter.Items1" xml:space="preserve">
-    <value>Hiển thị các mục khởi động</value>
+    <value>Hiển thị các mục khởi động cùng hệ thống</value>
   </data>
   <data name="comboBoxFilter.Items2" xml:space="preserve">
     <value>Hiển thị các tác vụ</value>
@@ -142,19 +142,19 @@
     <value>Xuất...</value>
   </data>
   <data name="columnHeader1.Text" xml:space="preserve">
-    <value>Tên ứng dụng</value>
+    <value>Tên chường trình</value>
   </data>
   <data name="columnHeader5.Text" xml:space="preserve">
     <value>Đã kích hoạt</value>
   </data>
   <data name="columnHeader2.Text" xml:space="preserve">
-    <value>Nhà xuất bản</value>
+    <value>Nhà phát hành</value>
   </data>
   <data name="columnHeader3.Text" xml:space="preserve">
     <value>Vị trí</value>
   </data>
   <data name="columnHeader4.Text" xml:space="preserve">
-    <value>Lệnh</value>
+    <value>Câu lệnh</value>
   </data>
   <data name="openFileLocationToolStripMenuItem.Text" xml:space="preserve">
     <value>&amp;Mở vị trí tệp thực thi</value>
@@ -163,7 +163,7 @@
     <value>Mở liên kết</value>
   </data>
   <data name="runCommandToolStripMenuItem.Text" xml:space="preserve">
-    <value>&amp;Thực thi lệnh</value>
+    <value>&amp;Thực thi câu lệnh</value>
   </data>
   <data name="copyToClipboardToolStripMenuItem.Text" xml:space="preserve">
     <value>&amp;Sao chép vào bảng nhớ tạm</value>
@@ -172,7 +172,7 @@
     <value>Tạo &amp;bản sao lưu</value>
   </data>
   <data name="moveToRegistryToolStripMenuItem.Text" xml:space="preserve">
-    <value>Di chuyển đến thanh ghi</value>
+    <value>Di chuyển đến registry</value>
   </data>
   <data name="runForAllUsersToolStripMenuItem.Text" xml:space="preserve">
     <value>Chạy cho tất cả người dùng</value>
@@ -184,18 +184,18 @@
     <value>&amp;Xoá</value>
   </data>
   <data name="groupBox1.Text" xml:space="preserve">
-    <value>Danh sách các lệnh có thể chạy tự động mà không cần sự tương tác của người dùng</value>
+    <value>Danh sách các câu lệnh có thể được thực thi tự động mà không cần sự can thiệp của người dùng</value>
   </data>
   <data name="exportDialog.Filter" xml:space="preserve">
     <value>Tệp văn bản|*.txt</value>
   </data>
   <data name="exportDialog.Title" xml:space="preserve">
-    <value>Xuất các mục khởi động...</value>
+    <value>Xuất các mục khởi động cùng hệ thống...</value>
   </data>
   <data name="folderBrowserDialog.Description" xml:space="preserve">
     <value>Chọn một thư mục trống để sao lưu.</value>
   </data>
   <data name="$this.Text" xml:space="preserve">
-    <value>Trình quản lý Khởi động</value>
+    <value>Trình quản lý Khởi động cùng hệ thống</value>
   </data>
 </root>

--- a/source/UninstallTools/Properties/Localisation.vi.resx
+++ b/source/UninstallTools/Properties/Localisation.vi.resx
@@ -151,7 +151,7 @@
     <value>Được bảo vệ</value>
   </data>
   <data name="IsUpdate" xml:space="preserve">
-    <value>Một bản cập nhật</value>
+    <value>Một ứng dụng cập nhật</value>
   </data>
   <data name="IsValid" xml:space="preserve">
     <value>Hợp lệ</value>
@@ -160,22 +160,22 @@
     <value>Sửa đổi đường dẫn</value>
   </data>
   <data name="Publisher" xml:space="preserve">
-    <value>Tên nhà xuất bản</value>
+    <value>Tên nhà phát hành</value>
   </data>
   <data name="PublisherTrimmed" xml:space="preserve">
-    <value>Tên rút gọn của nhà xuất bản</value>
+    <value>Tên rút gọn của nhà phát hành</value>
   </data>
   <data name="QuietUninstallPossible" xml:space="preserve">
-    <value>Có thể được gỡ cài đặt âm thầm</value>
+    <value>Có thể gỡ cài đặt âm thầm</value>
   </data>
   <data name="QuietUninstallString" xml:space="preserve">
-    <value>Lệnh gỡ cài đặt âm thầm</value>
+    <value>Câu lệnh gỡ cài đặt âm thầm</value>
   </data>
   <data name="RegistryKeyName" xml:space="preserve">
-    <value>Tên khoá thanh ghi</value>
+    <value>Tên khoá registry</value>
   </data>
   <data name="RegistryPath" xml:space="preserve">
-    <value>Đường dẫn thanh ghi</value>
+    <value>Đường dẫn registry</value>
   </data>
   <data name="SystemComponent" xml:space="preserve">
     <value>Một thành phần hệ thống</value>
@@ -187,10 +187,10 @@
     <value>Loại trình gỡ cài đặt</value>
   </data>
   <data name="UninstallPossible" xml:space="preserve">
-    <value>Có thể được gỡ cài đặt</value>
+    <value>Có thể gỡ cài đặt</value>
   </data>
   <data name="UninstallString" xml:space="preserve">
-    <value>Lệnh gỡ cài đặt</value>
+    <value>Câu lệnh gỡ cài đặt</value>
   </data>
   <data name="Comment" xml:space="preserve">
     <value>Chú thích</value>
@@ -245,13 +245,13 @@
     <value>Tên công ty trùng khớp</value>
   </data>
   <data name="ConfidencePart_DirectoryStillUsed" xml:space="preserve">
-    <value>Thư mục đang được sử dụng bởi một ứng dụng đã cài đặt khác</value>
+    <value>Thư mục đang được sử dụng bởi một ứng dụng khác</value>
   </data>
   <data name="ConfidencePart_ExplicitConnection" xml:space="preserve">
     <value>Mục được đề cập rõ ràng trong trình gỡ cài đặt</value>
   </data>
   <data name="ConfidencePart_IsUninstallerRegistryKey" xml:space="preserve">
-    <value>Mục thanh ghi của trình gỡ cài đặt</value>
+    <value>Mục registry của trình gỡ cài đặt</value>
   </data>
   <data name="ConfidencePart_ItemNameEqualsCompanyName" xml:space="preserve">
     <value>Mục này dường như là toàn bộ danh mục của nhà xuất bản</value>
@@ -260,7 +260,7 @@
     <value>Tên sản phẩm không khớp lắm</value>
   </data>
   <data name="ConfidencePart_ProductNamePerfectMatch" xml:space="preserve">
-    <value>Tên sản phẩm trùng khớp chính xác</value>
+    <value>Tên sản phẩm trùng khớp hoàn toàn</value>
   </data>
   <data name="ConfidencePart_QuestionableDirectoryName" xml:space="preserve">
     <value>Tên thư mục rất đáng ngờ</value>
@@ -308,7 +308,7 @@
     <value>Đang chờ</value>
   </data>
   <data name="IsRegistered" xml:space="preserve">
-    <value>Ứng dụng đã được đăng ký</value>
+    <value>Ứng dụng đã đăng ký</value>
   </data>
   <data name="UninstallListEditor_InvalidFilter" xml:space="preserve">
     <value>Bộ lọc không hợp lệ</value>
@@ -317,7 +317,7 @@
     <value>Bộ lọc mới</value>
   </data>
   <data name="UninstallListEditor_NothingMatched" xml:space="preserve">
-    <value>Không khớp</value>
+    <value>Không trùng khớp</value>
   </data>
   <data name="FilterComparisonMethod_Contains" xml:space="preserve">
     <value>Chứa tất cả ký tự</value>
@@ -343,16 +343,16 @@
     <comment>As in "matches any word from this string"</comment>
   </data>
   <data name="StartupEntries" xml:space="preserve">
-    <value>Lệnh khởi động</value>
+    <value>Câu lệnh khởi động cùng hệ thống</value>
   </data>
   <data name="StartupManager_Message_Delete_Details" xml:space="preserve">
-    <value>Chúng sẽ không còn được mở trong khi khởi động. Hãy đảm bảo rằng các mục đã chọn không cần thiết trước khi gỡ bỏ chúng.</value>
+    <value>Các mục đã chọn sẽ không còn được mở tự động trong quá trình khởi động. Hãy đảm bảo các mục này không cần thiết trước khi xóa chúng.</value>
   </data>
   <data name="StartupManager_Message_Delete_Header" xml:space="preserve">
-    <value>Xoá các ứng dụng đã chọn khỏi quá trình khởi động?</value>
+    <value>Loại bỏ các chương trình đã chọn khỏi quá trình khởi động cùng hệ thống?</value>
   </data>
   <data name="StartupManager_Message_Delete_Title" xml:space="preserve">
-    <value>Trình quản lý Khởi động</value>
+    <value>Trình quản lý Khởi động cùng hệ thống</value>
   </data>
   <data name="StartupManager_Loading" xml:space="preserve">
     <value>Đang nạp...</value>
@@ -370,13 +370,13 @@
     <value>Rất nhiều tệp tin hiện có</value>
   </data>
   <data name="Confidence_PF_NameIsUsed" xml:space="preserve">
-    <value>Tên ứng dụng được công nhận</value>
+    <value>Tên chương trình được công nhận</value>
   </data>
   <data name="Confidence_PF_NoSubdirs" xml:space="preserve">
     <value>Không có thư mục con</value>
   </data>
   <data name="Confidence_PF_PublisherIsUsed" xml:space="preserve">
-    <value>Nhà xuất bản được công nhận</value>
+    <value>Nhà phát hành được công nhận</value>
   </data>
   <data name="Confidence_Startup_IsRunOnce" xml:space="preserve">
     <value>Mục nhập chỉ được thực thi một lần</value>
@@ -388,13 +388,13 @@
     <value>Các tệp và thư mục</value>
   </data>
   <data name="Junk_ProgramFilesOrphans_GroupName" xml:space="preserve">
-    <value>Các tệp ứng dụng mồ côi</value>
+    <value>Các tệp chương trình mồ côi</value>
   </data>
   <data name="Junk_Registry_GroupName" xml:space="preserve">
-    <value>Thanh ghi</value>
+    <value>Registry</value>
   </data>
   <data name="Junk_Startup_GroupName" xml:space="preserve">
-    <value>Khởi động</value>
+    <value>Khởi động cùng hệ thống</value>
   </data>
   <data name="StartupManager_FailedEnable_FileNotFound" xml:space="preserve">
     <value>Không thể kích hoạt mục này, các tệp sau không được tìm thấy:</value>
@@ -416,7 +416,7 @@
     <value>Giá trị không thể chứa ký tự thoát dòng mới (\n)</value>
   </data>
   <data name="Error_InvalidRegKeys" xml:space="preserve">
-    <value>(Các) khóa thanh ghi khởi động không hợp lệ hoặc không xác định: </value>
+    <value>(Các) khóa registry khởi động cùng hệ thống không hợp lệ hoặc không xác định: </value>
   </data>
   <data name="UninstallerType_StoreApp" xml:space="preserve">
     <value>Windows Store App</value>
@@ -425,17 +425,17 @@
     <value>Điều kiện mới</value>
   </data>
   <data name="IsOrphaned" xml:space="preserve">
-    <value>Chưa được đăng ký</value>
+    <value>Chưa đăng ký</value>
     <comment>Present on the HDD but is not properly reported anywhere</comment>
   </data>
   <data name="ConfidencePart_IsStoreApp" xml:space="preserve">
     <value>Việc xóa dữ liệu Store App có vấn đề</value>
   </data>
   <data name="UninstallerType_SimpleDelete" xml:space="preserve">
-    <value>Xoá Đơn giản</value>
+    <value>Xoá đơn giản</value>
   </data>
   <data name="ConfidencePart_AllSubdirsMatched" xml:space="preserve">
-    <value>Thư mục trống hoặc vẫn trống ngay cả sau khi xóa rác.</value>
+    <value>Thư mục trống hoặc vẫn trống ngay cả sau khi loại bỏ rác.</value>
   </data>
   <data name="Startup_ShortName_Service" xml:space="preserve">
     <value>Dịch vụ</value>
@@ -451,46 +451,46 @@
     <value>Đã tìm thấy {0} GUID ứng dụng</value>
   </data>
   <data name="Progress_Registry" xml:space="preserve">
-    <value>Đang quét thanh ghi để tìm trình gỡ cài đặt...</value>
+    <value>Đang quét registry để tìm các trình gỡ cài đặt...</value>
   </data>
   <data name="Progress_Registry_Gathering" xml:space="preserve">
-    <value>Đang thu thập các khoá thanh ghi...</value>
+    <value>Đang thu thập các khoá registry...</value>
   </data>
   <data name="Progress_Registry_Processing" xml:space="preserve">
-    <value>Đang xử lý {0}</value>
+    <value>Đang quét {0}</value>
   </data>
   <data name="Progress_GatherUninstallerInfo" xml:space="preserve">
     <value>Đang tạo thông tin trình gỡ cài đặt bị thiếu...</value>
   </data>
   <data name="Progress_DriveScan" xml:space="preserve">
-    <value>Đang quét ổ đĩa để tìm ứng dụng...</value>
+    <value>Đang quét ổ đĩa để tìm các ứng dụng...</value>
   </data>
   <data name="Progress_DriveScan_Gathering" xml:space="preserve">
     <value>Đang thu thập thư mục...</value>
   </data>
   <data name="Progress_AppStores" xml:space="preserve">
-    <value>Đang quét kho ứng dụng...</value>
+    <value>Đang quét các kho ứng dụng...</value>
   </data>
   <data name="Progress_AppStores_Templates" xml:space="preserve">
-    <value>Đang tìm kiếm mẫu ứng dụng...</value>
+    <value>Đang tìm kiếm các mẫu ứng dụng...</value>
   </data>
   <data name="Progress_AppStores_Steam" xml:space="preserve">
-    <value>Đang tìm kiếm Steam App</value>
+    <value>Đang kiểm tra Steam App...</value>
   </data>
   <data name="Progress_AppStores_WinStore" xml:space="preserve">
-    <value>Đang tìm kiếm Windows Store App</value>
+    <value>Đang kiểm tra Windows Store App...</value>
   </data>
   <data name="Progress_AppStores_WinFeatures" xml:space="preserve">
-    <value>Đang tìm kiếm Windows Features</value>
+    <value>Đang kiểm tra Windows Features...</value>
   </data>
   <data name="Progress_Merging" xml:space="preserve">
     <value>Đang hợp nhất các ứng dụng được phát hiện...</value>
   </data>
   <data name="Progress_Merging_Stores" xml:space="preserve">
-    <value>Đang hợp nhất các ứng dụng từ các kho ứng dụng</value>
+    <value>Đang hợp nhất các ứng dụng từ các kho ứng dụng...</value>
   </data>
   <data name="Progress_Merging_Drives" xml:space="preserve">
-    <value>Đang hợp nhất các ứng dụng từ các ổ đĩa</value>
+    <value>Đang hợp nhất các ứng dụng từ các ổ đĩa...</value>
   </data>
   <data name="Progress_GeneratingInfo" xml:space="preserve">
     <value>Đang tạo thông tin còn thiếu...</value>
@@ -499,7 +499,7 @@
     <value>Windows Update</value>
   </data>
   <data name="Progress_AppStores_WinUpdates" xml:space="preserve">
-    <value>Đang tìm kiếm các bản cập nhật Windows</value>
+    <value>Đang kiểm tra Windows Update...</value>
   </data>
   <data name="Junk_FirewallRule_GroupName" xml:space="preserve">
     <value>Quy tắc tường lửa</value>
@@ -547,10 +547,10 @@
     <value>Chocolatey</value>
   </data>
   <data name="UninstallStatus_Paused" xml:space="preserve">
-    <value>Tạm ngưng</value>
+    <value>Tạm dừng</value>
   </data>
   <data name="Progress_AppStores_Chocolatey" xml:space="preserve">
-    <value>Tìm kiếm các gói Chocolatey</value>
+    <value>Tìm kiểm tra các gói Chocolatey...</value>
   </data>
   <data name="ChocolateyFactory_UninstallInChocolateyJunkName" xml:space="preserve">
     <value>Gỡ cài đặt bằng Chocolatey</value>
@@ -560,10 +560,10 @@
     <value>Có thể tự động khởi động</value>
   </data>
   <data name="Progress_Startup" xml:space="preserve">
-    <value>Tìm kiếm các mục khởi động</value>
+    <value>Đang kiểm tra các mục khởi động cùng hệ thống...</value>
   </data>
   <data name="Progress_AppStores_Oculus" xml:space="preserve">
-    <value>Tìm kiếm Oculus App</value>
+    <value>Đang kiểm tra Oculus App...</value>
   </data>
   <data name="UninstallerType_Oculus" xml:space="preserve">
     <value>Oculus</value>
@@ -575,7 +575,7 @@
     <value>Tập lệnh PowerShell</value>
   </data>
   <data name="Progress_AppStores_Scoop" xml:space="preserve">
-    <value>Tìm kiếm các gói Scoop</value>
+    <value>Đang kiểm tra các gói Scoop...</value>
   </data>
   <data name="Junk_DebugTracing_GroupName" xml:space="preserve">
     <value>Cấu hình theo dõi/ghi nhật ký gỡ lỗi</value>

--- a/source/UninstallerAutomatizer/Forms/MainWindow.vi.resx
+++ b/source/UninstallerAutomatizer/Forms/MainWindow.vi.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="label1.Text" xml:space="preserve">
-    <value>Một công cụ tự động gỡ cài đặt các ứng dụng không có trình gỡ cài đặt âm thầm sẽ thay mặt người dùng nhấp vào nút trình gỡ cài đặt.</value>
+    <value>Công cụ này tự động gỡ cài đặt các ứng dụng không có trình gỡ cài đặt âm thầm bằng cách nhấp chuột vào các nút của trình gỡ cài đặt thay cho người dùng.</value>
   </data>
   <data name="groupBox1.Text" xml:space="preserve">
     <value>Trạng thái</value>
@@ -127,13 +127,13 @@
     <value>Tiếp tục</value>
   </data>
   <data name="buttonPause.Text" xml:space="preserve">
-    <value>Tạm ngưng</value>
+    <value>Tạm dừng</value>
   </data>
   <data name="buttonAbort.Text" xml:space="preserve">
     <value>Huỷ bỏ</value>
   </data>
   <data name="checkBoxUninstallerVisible.Text" xml:space="preserve">
-    <value>Trình gỡ cài đặt có thể nhìn thấy</value>
+    <value>Hiển thị trình gỡ cài đặt</value>
   </data>
   <data name="$this.Text" xml:space="preserve">
     <value>Tự động hoá việc gỡ cài đặt</value>

--- a/source/UninstallerAutomatizer/Properties/Localization.vi.resx
+++ b/source/UninstallerAutomatizer/Properties/Localization.vi.resx
@@ -127,7 +127,7 @@
     <value>Đường dẫn không hợp lệ hoặc tệp không tồn tại: {0}</value>
   </data>
   <data name="Error_NotSupported" xml:space="preserve">
-    <value>Tự động gỡ cài đặt cho {0} không được hỗ trợ.</value>
+    <value>Tự động hoá trình gỡ cài đặt cho {0} không được hỗ trợ.</value>
   </data>
   <data name="Message_Starting" xml:space="preserve">
     <value>Tự động gỡ cài đặt "{0}"</value>
@@ -142,21 +142,21 @@
     <value>Tự động gỡ cài đặt không thành công. Lý do: {0}</value>
   </data>
   <data name="Message_Automation_SelectingNotBadButton" xml:space="preserve">
-    <value>Chọn nút radio không nằm trong danh sách đen: {0}</value>
+    <value>Tích nút radio không nằm trong danh sách đen: {0}</value>
   </data>
   <data name="Message_Automation_SelectingGoodButton" xml:space="preserve">
-    <value>Chọn nút radio được biết là tốt</value>
+    <value>Tích nút radio được biết là tốt: {0}</value>
   </data>
   <data name="Message_Automation_FoundButtons" xml:space="preserve">
     <value>Đã tìm thấy {0} nút radio.</value>
     <comment>{0} is number of buttons</comment>
   </data>
   <data name="Message_Automation_ClickingButton" xml:space="preserve">
-    <value>Nhấp vào nút radio "{0}".</value>
+    <value>Nhấp chuột vào nút "{0}".</value>
     <comment>{0} is button name</comment>
   </data>
   <data name="Message_Automation_PopupClosed" xml:space="preserve">
-    <value>Cửa sổ bật lên đã đóng.</value>
+    <value>Đã đóng cửa sổ bật lên.</value>
   </data>
   <data name="Message_Automation_PopupFound" xml:space="preserve">
     <value>Đã tìm thấy một cửa sổ bật lên - "{0}".</value>
@@ -175,14 +175,14 @@
     <comment>"{0}" is window name</comment>
   </data>
   <data name="Message_Automation_WindowSearching" xml:space="preserve">
-    <value>Đang tìm kiếm cửa sổ...</value>
+    <value>Đang kiểm tra cửa sổ...</value>
   </data>
   <data name="Message_Automation_AppAttached" xml:space="preserve">
     <value>Đã đính kèm với "{0}".</value>
     <comment>0 is application name</comment>
   </data>
   <data name="Message_Automation_WaitingForNsisExtraction" xml:space="preserve">
-    <value>Đang chờ trình gỡ cài đặt NSIS triển khai...</value>
+    <value>Đang chờ trình gỡ cài đặt NSIS...</value>
   </data>
   <data name="Message_Automation_ProcessFailedToStart" xml:space="preserve">
     <value>Khởi động quá trình không thành công.</value>

--- a/source/UniversalUninstaller/Properties/Localisation.vi.resx
+++ b/source/UniversalUninstaller/Properties/Localisation.vi.resx
@@ -121,7 +121,7 @@
     <value>Số lượng đối số không hợp lệ. Chuyển đường dẫn đầy đủ của thư mục cần xóa làm đối số và tùy chọn /q cho chế độ âm thầm.</value>
   </data>
   <data name="Program_ShowInvalidArgsBox_Title" xml:space="preserve">
-    <value>Trình gỡ cài đặt Chung chung</value>
+    <value>Trình gỡ cài đặt đa năng</value>
   </data>
   <data name="UninstallSelection_DeleteProgress_Title" xml:space="preserve">
     <value>Đang xoá các mục</value>

--- a/source/UniversalUninstaller/UninstallSelection.vi.resx
+++ b/source/UniversalUninstaller/UninstallSelection.vi.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="labelMessage.Text" xml:space="preserve">
-    <value>Vui lòng chọn những tệp cần xóa. Bạn có thể nhấp đúp vào bất kỳ mục nào để xem mục đó trong Explorer. Để xem đường dẫn đầy đủ, hãy di chuột qua bất kỳ mục nào.
-Cảnh báo: Chỉ xóa những tệp mà bạn biết là không cần thiết.</value>
+    <value>Vui lòng chọn các tệp tin bạn muốn xóa. Bạn có thể nhấp đúp vào bất kỳ mục nào để xem chúng trong File Explorer. Để xem đường dẫn đầy đủ, hãy di chuột qua bất kỳ mục nào.
+Cảnh báo: Chỉ xóa những tệp mà bạn cho là không cần thiết.</value>
   </data>
 </root>


### PR DESCRIPTION
This PR improves the Vietnamese translation by removing redundancy, updating vocabulary, and enhancing grammar. These changes aim to ensure better clarity and accuracy throughout the Vietnamese content, enhancing the user experience for Vietnamese people.