### PR TITLE
Fix winget releaser workflow

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -4,16 +4,15 @@ on:
     types: [released]
 jobs:
   publish:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Get version
         id: get-version
         run: |
-          # Finding the version from release name
-          $VERSION = '${{ github.event.release.tag_name }}'.Replace('v', $Null) + '.0.0'
-          echo "::set-output name=version::$VERSION"
-        shell: pwsh
-      - uses: vedantmgoyal2009/winget-releaser@v2
+          # Find the version from tag name and pad to 4 components
+          version=$(echo "${{ github.event.release.tag_name }}" | awk -F. '{printf "%d.%d.%d.%d\n", substr($1, 2), $2, $3, $4}')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+      - uses: vedantmgoyal9/winget-releaser@main
         with:
           identifier: Klocman.BulkCrapUninstaller
           version: ${{ steps.get-version.outputs.version }}


### PR DESCRIPTION
- Fixes https://github.com/Klocman/Bulk-Crap-Uninstaller/issues/642

**Changes:**
- Change job runner from `windows-latest` to `ubuntu-latest` (runs faster)
- Update `vedantmgoyal2009/winget-releaser@v2` to `vedantmgoyal9/winget-releaser@main`
- Fix version extraction to properly pad to 4 components (`v5.8.1` now turns to `5.8.1.0` instead of `5.8.1.0.0`)
- Update [deprecated `set-output`](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) command

> [!IMPORTANT]
> **Before merging this:**
> 1. Ensure `WINGET_TOKEN` has the `public_repo` scope.
>
> ![example](https://user-images.githubusercontent.com/56180050/180631504-f19d12cc-19ce-4991-a753-d4f7ff0adbca.png)
>
> 2. The action has been failing since https://github.com/Klocman/winget-pkgs is very outdated. Please sync the fork and install [Pull](https://github.com/apps/pull) on the fork to ensure that it is constantly updated.

