### PR TITLE
Fix SubPathIsInsideBasePath returning false for exact match

### DIFF
--- a/source/BulkCrapUninstaller/Forms/Helpers/TargetWindow.cs
+++ b/source/BulkCrapUninstaller/Forms/Helpers/TargetWindow.cs
@@ -72,7 +72,7 @@ namespace BulkCrapUninstaller.Forms
                     throw new InvalidOperationException("Failed to get MainModule Directory");
 
                 // Ignore targeting BCU itself
-                if (PathTools.SubPathIsInsideBasePath(Program.AssemblyLocation.FullName, fileName, true))
+                if (PathTools.SubPathIsInsideBasePath(Program.AssemblyLocation.FullName, fileName, true, true))
                     return;
 
                 OnDirectoriesSelected(new DirectoriesSelectedEventArgs(parentDirectory.ToEnumerable().ToList()));

--- a/source/BulkCrapUninstaller/Program.cs
+++ b/source/BulkCrapUninstaller/Program.cs
@@ -199,7 +199,7 @@ namespace BulkCrapUninstaller
                             var installLocation = subKey?.GetStringSafe(RegistryFactory.RegistryNameInstallLocation);
                             if (string.IsNullOrEmpty(installLocation)) continue;
 
-                            if (PathTools.SubPathIsInsideBasePath(installLocation, AssemblyLocation.FullName, true))
+                            if (PathTools.SubPathIsInsideBasePath(installLocation, AssemblyLocation.FullName, true, true))
                             {
                                 // We are installed!
                                 _installedRegistryKeyName = keyName;

--- a/source/KlocTools/Tools/PathTools.cs
+++ b/source/KlocTools/Tools/PathTools.cs
@@ -350,7 +350,7 @@ namespace Klocman.Tools
         /// Check if subPath is a sub path inside basePath.
         /// If isFilesystemPath is true then attempt to normalize the path to its absolute form on the filesystem. Set to false for registry and other paths.
         /// </summary>
-        public static bool SubPathIsInsideBasePath(string basePath, string subPath, bool normalizeFilesystemPath)
+        public static bool SubPathIsInsideBasePath(string basePath, string subPath, bool normalizeFilesystemPath, bool includeExactMatch)
         {
             if (basePath == null) return false;
             basePath = NormalizePath(basePath).Replace('\\', '/');
@@ -370,7 +370,7 @@ namespace Klocman.Tools
                 catch (SystemException) { }
             }
 
-            return subPath.StartsWith(basePath + '/', StringComparison.InvariantCultureIgnoreCase);
+            return subPath.StartsWith(basePath + '/', StringComparison.InvariantCultureIgnoreCase) || includeExactMatch && subPath.Equals(basePath, StringComparison.InvariantCultureIgnoreCase);
         }
     }
 }

--- a/source/UninstallTools/Junk/Finders/Misc/ShortcutJunk.cs
+++ b/source/UninstallTools/Junk/Finders/Misc/ShortcutJunk.cs
@@ -59,8 +59,8 @@ namespace UninstallTools.Junk.Finders.Misc
                     var target = WindowsTools.ResolveShortcut(linkFilename);
 
                     if (string.IsNullOrEmpty(target) ||
-                        PathTools.SubPathIsInsideBasePath(syspath, target, true) ||
-                        PathTools.SubPathIsInsideBasePath(UninstallToolsGlobalConfig.AppLocation, target, true))
+                        PathTools.SubPathIsInsideBasePath(syspath, target, true, true) ||
+                        PathTools.SubPathIsInsideBasePath(UninstallToolsGlobalConfig.AppLocation, target, true, true))
                         continue;
 
                     results.Add(new Shortcut(linkFilename, target));

--- a/source/UninstallTools/Junk/Finders/Registry/ComScanner.cs
+++ b/source/UninstallTools/Junk/Finders/Registry/ComScanner.cs
@@ -39,7 +39,7 @@ namespace UninstallTools.Junk.Finders.Registry
             if (UninstallToolsGlobalConfig.IsSystemDirectory(target.InstallLocation))
                 yield break;
 
-            foreach (var comEntry in _comEntries.Where(x => PathTools.SubPathIsInsideBasePath(target.InstallLocation, x.FullFilename, true)))
+            foreach (var comEntry in _comEntries.Where(x => PathTools.SubPathIsInsideBasePath(target.InstallLocation, x.FullFilename, true, true)))
             {
                 foreach (var interfacePath in comEntry.InterfaceNames)
                 {

--- a/source/UninstallTools/Junk/Finders/Registry/EventLogScanner.cs
+++ b/source/UninstallTools/Junk/Finders/Registry/EventLogScanner.cs
@@ -38,13 +38,13 @@ namespace UninstallTools.Junk.Finders.Registry
                     using (var subkey = key.OpenSubKey(result))
                     {
                         var exePath = subkey?.GetStringSafe("EventMessageFile");
-                        if (string.IsNullOrEmpty(exePath) || !PathTools.SubPathIsInsideBasePath(target.InstallLocation, Path.GetDirectoryName(exePath), true)) continue;
+                        if (string.IsNullOrEmpty(exePath) || !PathTools.SubPathIsInsideBasePath(target.InstallLocation, Path.GetDirectoryName(exePath), true, false)) continue;
 
                         var node = new RegistryKeyJunk(subkey.Name, target, this);
                         // Already matched names above
                         node.Confidence.Add(ConfidenceRecords.ProductNamePerfectMatch);
 
-                        if (otherUninstallers.Any(x => PathTools.SubPathIsInsideBasePath(x.InstallLocation, Path.GetDirectoryName(exePath), true)))
+                        if (otherUninstallers.Any(x => PathTools.SubPathIsInsideBasePath(x.InstallLocation, Path.GetDirectoryName(exePath), true, false)))
                             node.Confidence.Add(ConfidenceRecords.DirectoryStillUsed);
 
                         yield return node;

--- a/source/UninstallTools/Junk/Finders/Registry/InstallerFoldersScanner.cs
+++ b/source/UninstallTools/Junk/Finders/Registry/InstallerFoldersScanner.cs
@@ -26,12 +26,12 @@ namespace UninstallTools.Junk.Finders.Registry
 
                 foreach (var valueName in key.GetValueNames())
                 {
-                    if (!PathTools.SubPathIsInsideBasePath(installLocation, valueName, true)) continue;
+                    if (!PathTools.SubPathIsInsideBasePath(installLocation, valueName, true, true)) continue;
 
                     var node = new RegistryValueJunk(key.Name, valueName, target, this);
                     node.Confidence.Add(ConfidenceRecords.ExplicitConnection);
 
-                    if (GetOtherInstallLocations(target).Any(x => PathTools.SubPathIsInsideBasePath(x, valueName, true)))
+                    if (GetOtherInstallLocations(target).Any(x => PathTools.SubPathIsInsideBasePath(x, valueName, true, true)))
                         node.Confidence.Add(ConfidenceRecords.DirectoryStillUsed);
 
                     yield return node;

--- a/source/UninstallTools/Junk/Finders/Registry/SoftwareRegKeyScanner.cs
+++ b/source/UninstallTools/Junk/Finders/Registry/SoftwareRegKeyScanner.cs
@@ -189,7 +189,7 @@ namespace UninstallTools.Junk.Finders.Registry
             bool hit;
             if (InstallDirKeyNames.Contains(valueName, StringComparison.InvariantCultureIgnoreCase))
             {
-                hit = PathTools.SubPathIsInsideBasePath(_uninstaller.InstallLocation, softwareKey.GetStringSafe(valueName), true);
+                hit = PathTools.SubPathIsInsideBasePath(_uninstaller.InstallLocation, softwareKey.GetStringSafe(valueName), true, true);
             }
             else if (ExePathKeyNames.Contains(valueName, StringComparison.InvariantCultureIgnoreCase))
             {
@@ -200,11 +200,11 @@ namespace UninstallTools.Junk.Finders.Registry
                 var path = softwareKey.GetStringSafe(valueName);
                 hit = File.Exists(path)
                     ? TestPathsMatchExe(softwareKey.GetStringSafe(valueName))
-                    : PathTools.SubPathIsInsideBasePath(_uninstaller.InstallLocation, softwareKey.GetStringSafe(valueName), true);
+                    : PathTools.SubPathIsInsideBasePath(_uninstaller.InstallLocation, softwareKey.GetStringSafe(valueName), true, true);
             }
             else
             {
-                hit = PathTools.SubPathIsInsideBasePath(_uninstaller.InstallLocation, softwareKey.GetStringSafe(null), true);
+                hit = PathTools.SubPathIsInsideBasePath(_uninstaller.InstallLocation, softwareKey.GetStringSafe(null), true, true);
             }
 
             return hit;
@@ -265,7 +265,7 @@ namespace UninstallTools.Junk.Finders.Registry
 
         private bool TestPathsMatchExe(string keyValue)
         {
-            return PathTools.SubPathIsInsideBasePath(_uninstaller.InstallLocation, Path.GetDirectoryName(keyValue), true);
+            return PathTools.SubPathIsInsideBasePath(_uninstaller.InstallLocation, Path.GetDirectoryName(keyValue), true, true);
         }
     }
 }


### PR DESCRIPTION
This affects junk generation and a few other things. Fixes some random issues and potentially improves junk detection.