### PR TITLE
Fix : Swedish translation causes UI overflow in some windows #810

### DIFF
--- a/source/BulkCrapUninstaller/Controls/Settings/UninstallationSettings.sv.resx
+++ b/source/BulkCrapUninstaller/Controls/Settings/UninstallationSettings.sv.resx
@@ -166,7 +166,7 @@
     <value>Automatisk avslutning vid väntan på användarindata</value>
   </data>
   <data name="checkBoxAutoDaemon.Text" xml:space="preserve">
-    <value>Bevaka "tysta" avinstallationsprogram för popup-fönster eller andra hinder och automatisera dem (kör automatizer daemon).</value>
+    <value>Automatisera tysta popup-fönster för avinstallation via daemon.</value>
   </data>
   <data name="groupBox1.Text" xml:space="preserve">
     <value>Tyst avinstallation</value>


### PR DESCRIPTION
This pull request fixes the UI overflow problems that were reported in #810 

After looking over the situation, I saw that some of the issues had already been fixed. I have fixed the last Swedish translation string that was messing up the layout so that it fits within the UI limits.

Changes:

Changed one Swedish translation strings so that text wouldn't wrap or overflow.

Checked that the UI now works properly in the windows that were affected.

Note to Klocman: In this PR i have only changed the swedish translation not the english ones and I will try to keep the changes short in future Pull Requests.