### PR TITLE
Added: 'Digital Signature' text column matching app list background #814

### DIFF
--- a/source/BulkCrapUninstaller/Forms/Windows/MainWindow.Designer.cs
+++ b/source/BulkCrapUninstaller/Forms/Windows/MainWindow.Designer.cs
@@ -1,8 +1,9 @@
-﻿using System.ComponentModel;
-using System.Windows.Forms;
-using BrightIdeasSoftware;
+﻿using BrightIdeasSoftware;
 using BulkCrapUninstaller.Controls;
 using BulkCrapUninstaller.Functions.Tracking;
+using System.ComponentModel;
+using System.Windows.Forms;
+using UninstallTools;
 
 namespace BulkCrapUninstaller.Forms
 {
@@ -46,6 +47,7 @@ namespace BulkCrapUninstaller.Forms
             olvColumnRegistryKeyName = new OLVColumn();
             olvColumnGuid = new OLVColumn();
             olvColumnQuietUninstallString = new OLVColumn();
+            olvColumnCertificate = new OLVColumn();
             treeMap1 = new SimpleTreeMap.TreeMap();
             toolStrip = new ToolStrip();
             toolStripButton1 = new ToolStripButton();
@@ -312,12 +314,13 @@ namespace BulkCrapUninstaller.Forms
             uninstallerObjectListView.AllColumns.Add(olvColumnRegistryKeyName);
             uninstallerObjectListView.AllColumns.Add(olvColumnGuid);
             uninstallerObjectListView.AllColumns.Add(olvColumnQuietUninstallString);
+            uninstallerObjectListView.AllColumns.Add(olvColumnCertificate);
             uninstallerObjectListView.AllowColumnReorder = true;
             uninstallerObjectListView.BorderStyle = BorderStyle.None;
             uninstallerObjectListView.CellEditActivation = ObjectListView.CellEditActivateMode.DoubleClick;
             uninstallerObjectListView.CellEditUseWholeCell = false;
             uninstallerObjectListView.CheckBoxes = true;
-            uninstallerObjectListView.Columns.AddRange(new ColumnHeader[] { olvColumnDisplayName, olvColumnPublisher, olvColumnRating, olvColumnDisplayVersion, olvColumnInstallDate, olvColumnSize, olvColumnStartup, olvColumnIs64, olvColumnUninstallString, olvColumnAbout, olvColumnInstallSource, olvColumnInstallLocation, olvColumnUninstallerKind, olvColumnSystemComponent, olvColumnProtected, olvColumnRegistryKeyName, olvColumnGuid, olvColumnQuietUninstallString });
+            uninstallerObjectListView.Columns.AddRange(new ColumnHeader[] { olvColumnDisplayName, olvColumnPublisher, olvColumnCertificate, olvColumnRating, olvColumnDisplayVersion, olvColumnInstallDate, olvColumnSize, olvColumnStartup, olvColumnIs64, olvColumnUninstallString, olvColumnAbout, olvColumnInstallSource, olvColumnInstallLocation, olvColumnUninstallerKind, olvColumnSystemComponent, olvColumnProtected, olvColumnRegistryKeyName, olvColumnGuid, olvColumnQuietUninstallString });
             resources.ApplyResources(uninstallerObjectListView, "uninstallerObjectListView");
             uninstallerObjectListView.FullRowSelect = true;
             uninstallerObjectListView.GridLines = true;
@@ -424,6 +427,10 @@ namespace BulkCrapUninstaller.Forms
             // olvColumnQuietUninstallString
             // 
             resources.ApplyResources(olvColumnQuietUninstallString, "olvColumnQuietUninstallString");
+            // 
+            // olvColumnCertificate
+            // 
+            resources.ApplyResources(olvColumnCertificate, "olvColumnCertificate");
             // 
             // treeMap1
             // 
@@ -1606,6 +1613,7 @@ namespace BulkCrapUninstaller.Forms
         internal OLVColumn olvColumnSystemComponent;
         internal OLVColumn olvColumnQuietUninstallString;
         internal OLVColumn olvColumnProtected;
+        internal OLVColumn olvColumnCertificate;
         private SaveFileDialog exportDialog;
         private ContextMenuStrip uninstallListContextMenuStrip;
         private ToolStripMenuItem uninstallContextMenuStripItem;

--- a/source/BulkCrapUninstaller/Forms/Windows/MainWindow.cs
+++ b/source/BulkCrapUninstaller/Forms/Windows/MainWindow.cs
@@ -218,15 +218,12 @@ namespace BulkCrapUninstaller.Forms
                 var entry = x as ApplicationUninstallerEntry;
                 if (entry == null) return string.Empty;
 
-                // Check special application types first
-                if (entry.UninstallerKind == UninstallerType.StoreApp) return "Windows Store App";
-                if (entry.UninstallerKind == UninstallerType.WindowsFeature) return "Windows Feature";
-                if (!entry.IsRegistered) return "Unregistered";
-
-                // Check certificate validity
+                if (entry.UninstallerKind == UninstallerType.StoreApp || entry.UninstallerKind == UninstallerType.WindowsFeature || !entry.IsRegistered)
+                    return "---";
+                
                 var certValid = entry.IsCertificateValid(false);
-                if (certValid == null) return "Unverified";
-                return certValid.Value ? "Verified" : "Invalid";
+                if (certValid == null) return "No";
+                return certValid.Value ? "Yes" : "Invalid";
             };
         }
 

--- a/source/BulkCrapUninstaller/Forms/Windows/MainWindow.cs
+++ b/source/BulkCrapUninstaller/Forms/Windows/MainWindow.cs
@@ -212,6 +212,22 @@ namespace BulkCrapUninstaller.Forms
             _setMan.Selected.Subscribe((x, y) => splitContainerListAndMap.Panel2Collapsed = !y.NewValue, settings => settings.ShowTreeMap, this);
 
             uninstallerObjectListView.ContextMenuStrip = uninstallListContextMenuStrip;
+
+            this.olvColumnCertificate.AspectGetter = delegate (object x)
+            {
+                var entry = x as ApplicationUninstallerEntry;
+                if (entry == null) return string.Empty;
+
+                // Check special application types first
+                if (entry.UninstallerKind == UninstallerType.StoreApp) return "Windows Store App";
+                if (entry.UninstallerKind == UninstallerType.WindowsFeature) return "Windows Feature";
+                if (!entry.IsRegistered) return "Unregistered";
+
+                // Check certificate validity
+                var certValid = entry.IsCertificateValid(false);
+                if (certValid == null) return "Unverified";
+                return certValid.Value ? "Verified" : "Invalid";
+            };
         }
 
         protected override void OnDpiChanged(DpiChangedEventArgs e)

--- a/source/BulkCrapUninstaller/Forms/Windows/MainWindow.resx
+++ b/source/BulkCrapUninstaller/Forms/Windows/MainWindow.resx
@@ -289,6 +289,12 @@
   <data name="olvColumnQuietUninstallString.Width" type="System.Int32, mscorlib">
     <value>160</value>
   </data>
+  <data name="olvColumnCertificate.Text" xml:space="preserve">
+    <value>Digital Signature</value>
+  </data>
+  <data name="olvColumnCertificate.Width" type="System.Int32, mscorlib">
+    <value>100</value>
+  </data>
   <data name="uninstallerObjectListView.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
@@ -299,7 +305,7 @@
     <value>4, 3, 4, 3</value>
   </data>
   <data name="uninstallerObjectListView.Size" type="System.Drawing.Size, System.Drawing">
-    <value>377, 485</value>
+    <value>889, 470</value>
   </data>
   <data name="uninstallerObjectListView.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -326,7 +332,7 @@
     <value>4, 3, 4, 3</value>
   </data>
   <data name="listViewPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>379, 487</value>
+    <value>891, 472</value>
   </data>
   <data name="listViewPanel.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -365,7 +371,7 @@
     <value>5, 3, 5, 3</value>
   </data>
   <data name="treeMap1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>379, 56</value>
+    <value>891, 71</value>
   </data>
   <data name="treeMap1.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -395,10 +401,10 @@
     <value>1</value>
   </data>
   <data name="splitContainerListAndMap.Size" type="System.Drawing.Size, System.Drawing">
-    <value>379, 548</value>
+    <value>891, 548</value>
   </data>
   <data name="splitContainerListAndMap.SplitterDistance" type="System.Int32, mscorlib">
-    <value>487</value>
+    <value>472</value>
   </data>
   <data name="splitContainerListAndMap.SplitterWidth" type="System.Int32, mscorlib">
     <value>5</value>
@@ -631,7 +637,7 @@
     <value>0, 0, 0, 1</value>
   </data>
   <data name="toolStrip.Size" type="System.Drawing.Size, System.Drawing">
-    <value>379, 30</value>
+    <value>891, 30</value>
   </data>
   <data name="toolStrip.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -655,7 +661,7 @@
     <value>No</value>
   </data>
   <data name="toolStripLabelStatus.Size" type="System.Drawing.Size, System.Drawing">
-    <value>62, 17</value>
+    <value>574, 17</value>
   </data>
   <data name="toolStripLabelStatus.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
     <value>MiddleLeft</value>
@@ -688,7 +694,7 @@
     <value>1, 0, 16, 0</value>
   </data>
   <data name="statusStrip1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>379, 22</value>
+    <value>891, 22</value>
   </data>
   <data name="statusStrip1.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -718,7 +724,7 @@
     <value>1</value>
   </data>
   <data name="splitContainer1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>803, 600</value>
+    <value>1315, 600</value>
   </data>
   <data name="splitContainer1.SplitterDistance" type="System.Int32, mscorlib">
     <value>417</value>
@@ -2130,7 +2136,7 @@
     <value>0, 2, 0, 2</value>
   </data>
   <data name="menuStrip.Size" type="System.Drawing.Size, System.Drawing">
-    <value>1029, 24</value>
+    <value>1541, 24</value>
   </data>
   <data name="menuStrip.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -2166,7 +2172,7 @@
     <value>7, 15</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>1031, 624</value>
+    <value>1543, 624</value>
   </data>
   <data name="$this.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>4, 3, 4, 3</value>
@@ -2286,6 +2292,12 @@
     <value>olvColumnQuietUninstallString</value>
   </data>
   <data name="&gt;&gt;olvColumnQuietUninstallString.Type" xml:space="preserve">
+    <value>BrightIdeasSoftware.OLVColumn, ObjectListView, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;olvColumnCertificate.Name" xml:space="preserve">
+    <value>olvColumnCertificate</value>
+  </data>
+  <data name="&gt;&gt;olvColumnCertificate.Type" xml:space="preserve">
     <value>BrightIdeasSoftware.OLVColumn, ObjectListView, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;toolStripButton1.Name" xml:space="preserve">

--- a/source/BulkCrapUninstaller/Forms/Windows/MainWindow.resx
+++ b/source/BulkCrapUninstaller/Forms/Windows/MainWindow.resx
@@ -305,7 +305,7 @@
     <value>4, 3, 4, 3</value>
   </data>
   <data name="uninstallerObjectListView.Size" type="System.Drawing.Size, System.Drawing">
-    <value>889, 470</value>
+    <value>889, 468</value>
   </data>
   <data name="uninstallerObjectListView.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -332,7 +332,7 @@
     <value>4, 3, 4, 3</value>
   </data>
   <data name="listViewPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>891, 472</value>
+    <value>891, 470</value>
   </data>
   <data name="listViewPanel.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -371,7 +371,7 @@
     <value>5, 3, 5, 3</value>
   </data>
   <data name="treeMap1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>891, 71</value>
+    <value>891, 73</value>
   </data>
   <data name="treeMap1.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -404,7 +404,7 @@
     <value>891, 548</value>
   </data>
   <data name="splitContainerListAndMap.SplitterDistance" type="System.Int32, mscorlib">
-    <value>472</value>
+    <value>470</value>
   </data>
   <data name="splitContainerListAndMap.SplitterWidth" type="System.Int32, mscorlib">
     <value>5</value>


### PR DESCRIPTION
This pull request implements the feature requested in #814 by adding a Status text column to the application list. The goal is to improve accessibility and make it easier to understand the application without relying only on background colors.

Currently, the background color of items in the main window is used to indicate different states such as Verified Certificate, Unverified, Unregistered Application, Windows Store App, and Missing Uninstaller. While this works visually, conveying information only through colors can be difficult for colorblind users. A text-based column provides the same information in a clearer and more accessible way.

Changes:

Added a Digital Signature column in the application list, placed after Publisher Column(index 2).

The column displays the textual equivalent of the background color state (Verified Certificate, Unverified, Unregistered Application, Windows Store App, Missing Uninstaller).

This improves accessibility for colorblind users and adds a small quality-of-life improvement for organizing apps.

Note to Klocman: I have used GitHub Copilot to help implement parts of the certification status functionality.

