### PR TITLE
Add certificate and integrity columns to app list

### DIFF
--- a/source/BulkCrapUninstaller/BulkCrapUninstaller.csproj
+++ b/source/BulkCrapUninstaller/BulkCrapUninstaller.csproj
@@ -58,6 +58,10 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<InternalsVisibleTo Include="BulkCrapUninstallerTests" />
+	</ItemGroup>
+
+	<ItemGroup>
 		<PackageReference Include="Microsoft.VisualBasic" Version="10.3.0" />
 	</ItemGroup>
 

--- a/source/BulkCrapUninstaller/Forms/Windows/MainWindow.Designer.cs
+++ b/source/BulkCrapUninstaller/Forms/Windows/MainWindow.Designer.cs
@@ -405,17 +405,17 @@ namespace BulkCrapUninstaller.Forms
             // olvColumnUninstallerKind
             // 
             resources.ApplyResources(olvColumnUninstallerKind, "olvColumnUninstallerKind");
-            // 
+            //
             // olvColumnSystemComponent
-            // 
+            //
             resources.ApplyResources(olvColumnSystemComponent, "olvColumnSystemComponent");
-            // 
+            //
             // olvColumnStatus
-            // 
+            //
             resources.ApplyResources(olvColumnStatus, "olvColumnStatus");
-            // 
+            //
             // olvColumnProtected
-            // 
+            //
             olvColumnProtected.AspectName = "IsProtected";
             resources.ApplyResources(olvColumnProtected, "olvColumnProtected");
             // 

--- a/source/BulkCrapUninstaller/Forms/Windows/MainWindow.Designer.cs
+++ b/source/BulkCrapUninstaller/Forms/Windows/MainWindow.Designer.cs
@@ -42,6 +42,7 @@ namespace BulkCrapUninstaller.Forms
             olvColumnInstallLocation = new OLVColumn();
             olvColumnUninstallerKind = new OLVColumn();
             olvColumnSystemComponent = new OLVColumn();
+            olvColumnStatus = new OLVColumn();
             olvColumnProtected = new OLVColumn();
             olvColumnRegistryKeyName = new OLVColumn();
             olvColumnGuid = new OLVColumn();
@@ -308,6 +309,7 @@ namespace BulkCrapUninstaller.Forms
             uninstallerObjectListView.AllColumns.Add(olvColumnInstallLocation);
             uninstallerObjectListView.AllColumns.Add(olvColumnUninstallerKind);
             uninstallerObjectListView.AllColumns.Add(olvColumnSystemComponent);
+            uninstallerObjectListView.AllColumns.Add(olvColumnStatus);
             uninstallerObjectListView.AllColumns.Add(olvColumnProtected);
             uninstallerObjectListView.AllColumns.Add(olvColumnRegistryKeyName);
             uninstallerObjectListView.AllColumns.Add(olvColumnGuid);
@@ -317,7 +319,7 @@ namespace BulkCrapUninstaller.Forms
             uninstallerObjectListView.CellEditActivation = ObjectListView.CellEditActivateMode.DoubleClick;
             uninstallerObjectListView.CellEditUseWholeCell = false;
             uninstallerObjectListView.CheckBoxes = true;
-            uninstallerObjectListView.Columns.AddRange(new ColumnHeader[] { olvColumnDisplayName, olvColumnPublisher, olvColumnRating, olvColumnDisplayVersion, olvColumnInstallDate, olvColumnSize, olvColumnStartup, olvColumnIs64, olvColumnUninstallString, olvColumnAbout, olvColumnInstallSource, olvColumnInstallLocation, olvColumnUninstallerKind, olvColumnSystemComponent, olvColumnProtected, olvColumnRegistryKeyName, olvColumnGuid, olvColumnQuietUninstallString });
+            uninstallerObjectListView.Columns.AddRange(new ColumnHeader[] { olvColumnDisplayName, olvColumnPublisher, olvColumnRating, olvColumnDisplayVersion, olvColumnInstallDate, olvColumnSize, olvColumnStartup, olvColumnIs64, olvColumnUninstallString, olvColumnAbout, olvColumnInstallSource, olvColumnInstallLocation, olvColumnUninstallerKind, olvColumnSystemComponent, olvColumnStatus, olvColumnProtected, olvColumnRegistryKeyName, olvColumnGuid, olvColumnQuietUninstallString });
             resources.ApplyResources(uninstallerObjectListView, "uninstallerObjectListView");
             uninstallerObjectListView.FullRowSelect = true;
             uninstallerObjectListView.GridLines = true;
@@ -407,6 +409,10 @@ namespace BulkCrapUninstaller.Forms
             // olvColumnSystemComponent
             // 
             resources.ApplyResources(olvColumnSystemComponent, "olvColumnSystemComponent");
+            // 
+            // olvColumnStatus
+            // 
+            resources.ApplyResources(olvColumnStatus, "olvColumnStatus");
             // 
             // olvColumnProtected
             // 
@@ -1604,6 +1610,7 @@ namespace BulkCrapUninstaller.Forms
         internal OLVColumn olvColumnAbout;
         internal OLVColumn olvColumnRegistryKeyName;
         internal OLVColumn olvColumnSystemComponent;
+        internal OLVColumn olvColumnStatus;
         internal OLVColumn olvColumnQuietUninstallString;
         internal OLVColumn olvColumnProtected;
         private SaveFileDialog exportDialog;

--- a/source/BulkCrapUninstaller/Forms/Windows/MainWindow.Designer.cs
+++ b/source/BulkCrapUninstaller/Forms/Windows/MainWindow.Designer.cs
@@ -30,6 +30,7 @@ namespace BulkCrapUninstaller.Forms
             uninstallerObjectListView = new ObjectListView();
             olvColumnDisplayName = new OLVColumn();
             olvColumnPublisher = new OLVColumn();
+            olvColumnCertificate = new OLVColumn();
             olvColumnRating = new OLVColumn();
             olvColumnDisplayVersion = new OLVColumn();
             olvColumnInstallDate = new OLVColumn();
@@ -42,7 +43,7 @@ namespace BulkCrapUninstaller.Forms
             olvColumnInstallLocation = new OLVColumn();
             olvColumnUninstallerKind = new OLVColumn();
             olvColumnSystemComponent = new OLVColumn();
-            olvColumnStatus = new OLVColumn();
+            olvColumnIntegrity = new OLVColumn();
             olvColumnProtected = new OLVColumn();
             olvColumnRegistryKeyName = new OLVColumn();
             olvColumnGuid = new OLVColumn();
@@ -297,6 +298,7 @@ namespace BulkCrapUninstaller.Forms
             // 
             uninstallerObjectListView.AllColumns.Add(olvColumnDisplayName);
             uninstallerObjectListView.AllColumns.Add(olvColumnPublisher);
+            uninstallerObjectListView.AllColumns.Add(olvColumnCertificate);
             uninstallerObjectListView.AllColumns.Add(olvColumnRating);
             uninstallerObjectListView.AllColumns.Add(olvColumnDisplayVersion);
             uninstallerObjectListView.AllColumns.Add(olvColumnInstallDate);
@@ -309,7 +311,7 @@ namespace BulkCrapUninstaller.Forms
             uninstallerObjectListView.AllColumns.Add(olvColumnInstallLocation);
             uninstallerObjectListView.AllColumns.Add(olvColumnUninstallerKind);
             uninstallerObjectListView.AllColumns.Add(olvColumnSystemComponent);
-            uninstallerObjectListView.AllColumns.Add(olvColumnStatus);
+            uninstallerObjectListView.AllColumns.Add(olvColumnIntegrity);
             uninstallerObjectListView.AllColumns.Add(olvColumnProtected);
             uninstallerObjectListView.AllColumns.Add(olvColumnRegistryKeyName);
             uninstallerObjectListView.AllColumns.Add(olvColumnGuid);
@@ -319,7 +321,7 @@ namespace BulkCrapUninstaller.Forms
             uninstallerObjectListView.CellEditActivation = ObjectListView.CellEditActivateMode.DoubleClick;
             uninstallerObjectListView.CellEditUseWholeCell = false;
             uninstallerObjectListView.CheckBoxes = true;
-            uninstallerObjectListView.Columns.AddRange(new ColumnHeader[] { olvColumnDisplayName, olvColumnPublisher, olvColumnRating, olvColumnDisplayVersion, olvColumnInstallDate, olvColumnSize, olvColumnStartup, olvColumnIs64, olvColumnUninstallString, olvColumnAbout, olvColumnInstallSource, olvColumnInstallLocation, olvColumnUninstallerKind, olvColumnSystemComponent, olvColumnStatus, olvColumnProtected, olvColumnRegistryKeyName, olvColumnGuid, olvColumnQuietUninstallString });
+            uninstallerObjectListView.Columns.AddRange(new ColumnHeader[] { olvColumnDisplayName, olvColumnPublisher, olvColumnCertificate, olvColumnRating, olvColumnDisplayVersion, olvColumnInstallDate, olvColumnSize, olvColumnStartup, olvColumnIs64, olvColumnUninstallString, olvColumnAbout, olvColumnInstallSource, olvColumnInstallLocation, olvColumnUninstallerKind, olvColumnSystemComponent, olvColumnIntegrity, olvColumnProtected, olvColumnRegistryKeyName, olvColumnGuid, olvColumnQuietUninstallString });
             resources.ApplyResources(uninstallerObjectListView, "uninstallerObjectListView");
             uninstallerObjectListView.FullRowSelect = true;
             uninstallerObjectListView.GridLines = true;
@@ -383,13 +385,17 @@ namespace BulkCrapUninstaller.Forms
             // 
             olvColumnIs64.AspectName = "Is64Bit";
             resources.ApplyResources(olvColumnIs64, "olvColumnIs64");
-            // 
+            //
             // olvColumnUninstallString
-            // 
+            //
             resources.ApplyResources(olvColumnUninstallString, "olvColumnUninstallString");
-            // 
+            //
+            // olvColumnCertificate
+            //
+            resources.ApplyResources(olvColumnCertificate, "olvColumnCertificate");
+            //
             // olvColumnAbout
-            // 
+            //
             olvColumnAbout.Hyperlink = true;
             olvColumnAbout.IsEditable = false;
             resources.ApplyResources(olvColumnAbout, "olvColumnAbout");
@@ -410,9 +416,9 @@ namespace BulkCrapUninstaller.Forms
             //
             resources.ApplyResources(olvColumnSystemComponent, "olvColumnSystemComponent");
             //
-            // olvColumnStatus
+            // olvColumnIntegrity
             //
-            resources.ApplyResources(olvColumnStatus, "olvColumnStatus");
+            resources.ApplyResources(olvColumnIntegrity, "olvColumnIntegrity");
             //
             // olvColumnProtected
             //
@@ -1609,8 +1615,9 @@ namespace BulkCrapUninstaller.Forms
         internal OLVColumn olvColumnUninstallerKind;
         internal OLVColumn olvColumnAbout;
         internal OLVColumn olvColumnRegistryKeyName;
+        internal OLVColumn olvColumnCertificate;
         internal OLVColumn olvColumnSystemComponent;
-        internal OLVColumn olvColumnStatus;
+        internal OLVColumn olvColumnIntegrity;
         internal OLVColumn olvColumnQuietUninstallString;
         internal OLVColumn olvColumnProtected;
         private SaveFileDialog exportDialog;

--- a/source/BulkCrapUninstaller/Forms/Windows/MainWindow.Designer.cs
+++ b/source/BulkCrapUninstaller/Forms/Windows/MainWindow.Designer.cs
@@ -321,7 +321,7 @@ namespace BulkCrapUninstaller.Forms
             uninstallerObjectListView.CellEditActivation = ObjectListView.CellEditActivateMode.DoubleClick;
             uninstallerObjectListView.CellEditUseWholeCell = false;
             uninstallerObjectListView.CheckBoxes = true;
-            uninstallerObjectListView.Columns.AddRange(new ColumnHeader[] { olvColumnDisplayName, olvColumnPublisher, olvColumnCertificate, olvColumnRating, olvColumnDisplayVersion, olvColumnInstallDate, olvColumnSize, olvColumnStartup, olvColumnIs64, olvColumnUninstallString, olvColumnAbout, olvColumnInstallSource, olvColumnInstallLocation, olvColumnUninstallerKind, olvColumnSystemComponent, olvColumnIntegrity, olvColumnProtected, olvColumnRegistryKeyName, olvColumnGuid, olvColumnQuietUninstallString });
+            uninstallerObjectListView.Columns.AddRange(new ColumnHeader[] { olvColumnDisplayName, olvColumnPublisher, olvColumnCertificate, olvColumnRating, olvColumnDisplayVersion, olvColumnInstallDate, olvColumnSize, olvColumnStartup, olvColumnIs64, olvColumnUninstallString, olvColumnAbout, olvColumnInstallSource, olvColumnInstallLocation, olvColumnUninstallerKind, olvColumnSystemComponent, olvColumnProtected, olvColumnIntegrity, olvColumnRegistryKeyName, olvColumnGuid, olvColumnQuietUninstallString });
             resources.ApplyResources(uninstallerObjectListView, "uninstallerObjectListView");
             uninstallerObjectListView.FullRowSelect = true;
             uninstallerObjectListView.GridLines = true;
@@ -352,6 +352,10 @@ namespace BulkCrapUninstaller.Forms
             // olvColumnPublisher
             // 
             resources.ApplyResources(olvColumnPublisher, "olvColumnPublisher");
+            // 
+            // olvColumnCertificate
+            // 
+            resources.ApplyResources(olvColumnCertificate, "olvColumnCertificate");
             // 
             // olvColumnRating
             // 
@@ -385,17 +389,13 @@ namespace BulkCrapUninstaller.Forms
             // 
             olvColumnIs64.AspectName = "Is64Bit";
             resources.ApplyResources(olvColumnIs64, "olvColumnIs64");
-            //
+            // 
             // olvColumnUninstallString
-            //
+            // 
             resources.ApplyResources(olvColumnUninstallString, "olvColumnUninstallString");
-            //
-            // olvColumnCertificate
-            //
-            resources.ApplyResources(olvColumnCertificate, "olvColumnCertificate");
-            //
+            // 
             // olvColumnAbout
-            //
+            // 
             olvColumnAbout.Hyperlink = true;
             olvColumnAbout.IsEditable = false;
             resources.ApplyResources(olvColumnAbout, "olvColumnAbout");
@@ -411,17 +411,17 @@ namespace BulkCrapUninstaller.Forms
             // olvColumnUninstallerKind
             // 
             resources.ApplyResources(olvColumnUninstallerKind, "olvColumnUninstallerKind");
-            //
+            // 
             // olvColumnSystemComponent
-            //
+            // 
             resources.ApplyResources(olvColumnSystemComponent, "olvColumnSystemComponent");
-            //
+            // 
             // olvColumnIntegrity
-            //
+            // 
             resources.ApplyResources(olvColumnIntegrity, "olvColumnIntegrity");
-            //
+            // 
             // olvColumnProtected
-            //
+            // 
             olvColumnProtected.AspectName = "IsProtected";
             resources.ApplyResources(olvColumnProtected, "olvColumnProtected");
             // 

--- a/source/BulkCrapUninstaller/Forms/Windows/MainWindow.cs
+++ b/source/BulkCrapUninstaller/Forms/Windows/MainWindow.cs
@@ -354,8 +354,21 @@ namespace BulkCrapUninstaller.Forms
             _uninstallerListPostProcesser.Dispose();
         }
 
+        private static bool _certificateColumnWasEnabled = true;
         private void OnTestCertificatesChanged(object x, SettingChangedEventArgs<bool> y)
         {
+            if (!y.NewValue)
+            {
+                _certificateColumnWasEnabled = olvColumnCertificate.IsVisible;
+                olvColumnCertificate.IsVisible = false;
+                uninstallerObjectListView.RebuildColumns();
+            }
+            else
+            {
+                olvColumnCertificate.IsVisible = _certificateColumnWasEnabled;
+                uninstallerObjectListView.RebuildColumns();
+            }
+
             if (!_listView.FirstRefreshCompleted)
                 return;
             if (y.NewValue) _uninstallerListPostProcesser.StartProcessingThread(_listView.FilteredUninstallers);

--- a/source/BulkCrapUninstaller/Forms/Windows/MainWindow.resx
+++ b/source/BulkCrapUninstaller/Forms/Windows/MainWindow.resx
@@ -265,6 +265,12 @@
   <data name="olvColumnSystemComponent.Width" type="System.Int32, mscorlib">
     <value>40</value>
   </data>
+  <data name="olvColumnStatus.Text" xml:space="preserve">
+    <value>Status</value>
+  </data>
+  <data name="olvColumnStatus.Width" type="System.Int32, mscorlib">
+    <value>120</value>
+  </data>
   <data name="olvColumnProtected.Text" xml:space="preserve">
     <value>Protected</value>
   </data>
@@ -2262,6 +2268,12 @@
     <value>olvColumnSystemComponent</value>
   </data>
   <data name="&gt;&gt;olvColumnSystemComponent.Type" xml:space="preserve">
+    <value>BrightIdeasSoftware.OLVColumn, ObjectListView, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;olvColumnStatus.Name" xml:space="preserve">
+    <value>olvColumnStatus</value>
+  </data>
+  <data name="&gt;&gt;olvColumnStatus.Type" xml:space="preserve">
     <value>BrightIdeasSoftware.OLVColumn, ObjectListView, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;olvColumnProtected.Name" xml:space="preserve">

--- a/source/BulkCrapUninstaller/Forms/Windows/MainWindow.resx
+++ b/source/BulkCrapUninstaller/Forms/Windows/MainWindow.resx
@@ -199,6 +199,12 @@
   <data name="olvColumnPublisher.Width" type="System.Int32, mscorlib">
     <value>160</value>
   </data>
+  <data name="olvColumnCertificate.Text" xml:space="preserve">
+    <value>Certificate</value>
+  </data>
+  <data name="olvColumnCertificate.Width" type="System.Int32, mscorlib">
+    <value>70</value>
+  </data>
   <data name="olvColumnRating.Text" xml:space="preserve">
     <value>User rating</value>
   </data>
@@ -265,17 +271,11 @@
   <data name="olvColumnSystemComponent.Width" type="System.Int32, mscorlib">
     <value>40</value>
   </data>
-  <data name="olvColumnCertificate.Text" xml:space="preserve">
-    <value>Certificate</value>
-  </data>
-  <data name="olvColumnCertificate.Width" type="System.Int32, mscorlib">
-    <value>120</value>
-  </data>
   <data name="olvColumnIntegrity.Text" xml:space="preserve">
     <value>Integrity</value>
   </data>
   <data name="olvColumnIntegrity.Width" type="System.Int32, mscorlib">
-    <value>120</value>
+    <value>85</value>
   </data>
   <data name="olvColumnProtected.Text" xml:space="preserve">
     <value>Protected</value>
@@ -311,7 +311,7 @@
     <value>4, 3, 4, 3</value>
   </data>
   <data name="uninstallerObjectListView.Size" type="System.Drawing.Size, System.Drawing">
-    <value>377, 485</value>
+    <value>377, 482</value>
   </data>
   <data name="uninstallerObjectListView.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -338,7 +338,7 @@
     <value>4, 3, 4, 3</value>
   </data>
   <data name="listViewPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>379, 487</value>
+    <value>379, 484</value>
   </data>
   <data name="listViewPanel.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -377,7 +377,7 @@
     <value>5, 3, 5, 3</value>
   </data>
   <data name="treeMap1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>379, 56</value>
+    <value>379, 59</value>
   </data>
   <data name="treeMap1.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -410,7 +410,7 @@
     <value>379, 548</value>
   </data>
   <data name="splitContainerListAndMap.SplitterDistance" type="System.Int32, mscorlib">
-    <value>487</value>
+    <value>484</value>
   </data>
   <data name="splitContainerListAndMap.SplitterWidth" type="System.Int32, mscorlib">
     <value>5</value>
@@ -2204,6 +2204,12 @@
   <data name="&gt;&gt;olvColumnPublisher.Type" xml:space="preserve">
     <value>BrightIdeasSoftware.OLVColumn, ObjectListView, Culture=neutral, PublicKeyToken=null</value>
   </data>
+  <data name="&gt;&gt;olvColumnCertificate.Name" xml:space="preserve">
+    <value>olvColumnCertificate</value>
+  </data>
+  <data name="&gt;&gt;olvColumnCertificate.Type" xml:space="preserve">
+    <value>BrightIdeasSoftware.OLVColumn, ObjectListView, Culture=neutral, PublicKeyToken=null</value>
+  </data>
   <data name="&gt;&gt;olvColumnRating.Name" xml:space="preserve">
     <value>olvColumnRating</value>
   </data>
@@ -2274,12 +2280,6 @@
     <value>olvColumnSystemComponent</value>
   </data>
   <data name="&gt;&gt;olvColumnSystemComponent.Type" xml:space="preserve">
-    <value>BrightIdeasSoftware.OLVColumn, ObjectListView, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;olvColumnCertificate.Name" xml:space="preserve">
-    <value>olvColumnCertificate</value>
-  </data>
-  <data name="&gt;&gt;olvColumnCertificate.Type" xml:space="preserve">
     <value>BrightIdeasSoftware.OLVColumn, ObjectListView, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;olvColumnIntegrity.Name" xml:space="preserve">

--- a/source/BulkCrapUninstaller/Forms/Windows/MainWindow.resx
+++ b/source/BulkCrapUninstaller/Forms/Windows/MainWindow.resx
@@ -265,10 +265,16 @@
   <data name="olvColumnSystemComponent.Width" type="System.Int32, mscorlib">
     <value>40</value>
   </data>
-  <data name="olvColumnStatus.Text" xml:space="preserve">
-    <value>Status</value>
+  <data name="olvColumnCertificate.Text" xml:space="preserve">
+    <value>Certificate</value>
   </data>
-  <data name="olvColumnStatus.Width" type="System.Int32, mscorlib">
+  <data name="olvColumnCertificate.Width" type="System.Int32, mscorlib">
+    <value>120</value>
+  </data>
+  <data name="olvColumnIntegrity.Text" xml:space="preserve">
+    <value>Integrity</value>
+  </data>
+  <data name="olvColumnIntegrity.Width" type="System.Int32, mscorlib">
     <value>120</value>
   </data>
   <data name="olvColumnProtected.Text" xml:space="preserve">
@@ -2270,10 +2276,16 @@
   <data name="&gt;&gt;olvColumnSystemComponent.Type" xml:space="preserve">
     <value>BrightIdeasSoftware.OLVColumn, ObjectListView, Culture=neutral, PublicKeyToken=null</value>
   </data>
-  <data name="&gt;&gt;olvColumnStatus.Name" xml:space="preserve">
-    <value>olvColumnStatus</value>
+  <data name="&gt;&gt;olvColumnCertificate.Name" xml:space="preserve">
+    <value>olvColumnCertificate</value>
   </data>
-  <data name="&gt;&gt;olvColumnStatus.Type" xml:space="preserve">
+  <data name="&gt;&gt;olvColumnCertificate.Type" xml:space="preserve">
+    <value>BrightIdeasSoftware.OLVColumn, ObjectListView, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;olvColumnIntegrity.Name" xml:space="preserve">
+    <value>olvColumnIntegrity</value>
+  </data>
+  <data name="&gt;&gt;olvColumnIntegrity.Type" xml:space="preserve">
     <value>BrightIdeasSoftware.OLVColumn, ObjectListView, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;olvColumnProtected.Name" xml:space="preserve">

--- a/source/BulkCrapUninstaller/Functions/ApplicationList/ApplicationListConstants.cs
+++ b/source/BulkCrapUninstaller/Functions/ApplicationList/ApplicationListConstants.cs
@@ -3,15 +3,50 @@
     Apache License Version 2.0
 */
 
+using System;
+using System.ComponentModel;
 using System.Drawing;
+using BulkCrapUninstaller.Controls;
 using BulkCrapUninstaller.Properties;
 using UninstallTools;
+using UninstallToolsLocalisation = UninstallTools.Properties.Localisation;
 
 namespace BulkCrapUninstaller.Functions.ApplicationList
 {
     internal static class ApplicationListConstants
     {
+        private static readonly ComponentResourceManager ListLegendResources = new(typeof(ListLegend));
+
         public static ApplicationListColors Colors => Settings.Default.MiscColorblind ? ApplicationListColors.ColorBlind : ApplicationListColors.Normal;
+
+        public static string GetApplicationStatusText(ApplicationUninstallerEntry entry)
+        {
+            if (entry == null) return Localisable.Empty;
+
+            if (Settings.Default.AdvancedHighlightSpecial)
+            {
+                if (entry.UninstallerKind == UninstallerType.WindowsFeature)
+                    return entry.UninstallerKind.GetLocalisedName();
+
+                if (entry.UninstallerKind == UninstallerType.StoreApp)
+                    return entry.UninstallerKind.GetLocalisedName();
+
+                if (entry.IsOrphaned)
+                    return UninstallToolsLocalisation.IsOrphaned;
+            }
+
+            if (!entry.IsValid && Settings.Default.AdvancedTestInvalid)
+                return UninstallToolsLocalisation.UninstallStatus_Invalid;
+
+            if (Settings.Default.AdvancedTestCertificates)
+            {
+                var result = entry.IsCertificateValid(true);
+                if (result.HasValue)
+                    return result.Value ? GetListLegendText("labelVerified.Text", "Verified certificate") : GetListLegendText("labelUnverified.Text", "Unverified certificate");
+            }
+
+            return Localisable.Empty;
+        }
 
         public static Color GetApplicationBackColor(ApplicationUninstallerEntry entry)
         {
@@ -66,6 +101,11 @@ namespace BulkCrapUninstaller.Functions.ApplicationList
             }
 
             return Color.White;
+        }
+
+        private static string GetListLegendText(string resourceName, string fallback)
+        {
+            return ListLegendResources.GetString(resourceName) ?? fallback;
         }
     }
 }

--- a/source/BulkCrapUninstaller/Functions/ApplicationList/ApplicationListConstants.cs
+++ b/source/BulkCrapUninstaller/Functions/ApplicationList/ApplicationListConstants.cs
@@ -3,10 +3,7 @@
     Apache License Version 2.0
 */
 
-using System;
-using System.ComponentModel;
 using System.Drawing;
-using BulkCrapUninstaller.Controls;
 using BulkCrapUninstaller.Properties;
 using UninstallTools;
 
@@ -14,8 +11,6 @@ namespace BulkCrapUninstaller.Functions.ApplicationList
 {
     internal static class ApplicationListConstants
     {
-        private static readonly ComponentResourceManager ListLegendResources = new(typeof(ListLegend));
-
         public static ApplicationListColors Colors => Settings.Default.MiscColorblind ? ApplicationListColors.ColorBlind : ApplicationListColors.Normal;
 
         public static string GetApplicationCertificateText(ApplicationUninstallerEntry entry)
@@ -23,18 +18,16 @@ namespace BulkCrapUninstaller.Functions.ApplicationList
             if (entry == null) return Localisable.Empty;
 
             if (!Settings.Default.AdvancedTestCertificates)
-                return Localisable.Empty;
+                return "Disabled";
 
             var result = entry.IsCertificateValid(true);
             if (!result.HasValue)
                 return "None";
 
-            return result.Value
-                ? GetListLegendText("labelVerified.Text", "Verified certificate")
-                : GetListLegendText("labelUnverified.Text", "Unverified certificate");
+            return result.Value ? "Verified" : "Unverified";
         }
 
-        public static string GetApplicationIntegrityText(ApplicationUninstallerEntry entry)
+        public static object GetApplicationIntegrityText(ApplicationUninstallerEntry entry)
         {
             if (entry == null) return Localisable.Empty;
 
@@ -42,13 +35,13 @@ namespace BulkCrapUninstaller.Functions.ApplicationList
             var missingUninstaller = !entry.IsValid;
 
             if (missingRegistry && missingUninstaller)
-                return "Missing uninstaller and registry";
+                return new[] { "No uninstaller", "No registry" };
 
             if (missingRegistry)
-                return "Missing registry";
+                return "No registry";
 
             if (missingUninstaller)
-                return GetListLegendText("labelInvalid.Text", "Missing uninstaller");
+                return "No uninstaller";
 
             return "Good";
         }
@@ -106,11 +99,6 @@ namespace BulkCrapUninstaller.Functions.ApplicationList
             }
 
             return Color.White;
-        }
-
-        private static string GetListLegendText(string resourceName, string fallback)
-        {
-            return ListLegendResources.GetString(resourceName) ?? fallback;
         }
     }
 }

--- a/source/BulkCrapUninstaller/Functions/ApplicationList/ApplicationListConstants.cs
+++ b/source/BulkCrapUninstaller/Functions/ApplicationList/ApplicationListConstants.cs
@@ -19,33 +19,39 @@ namespace BulkCrapUninstaller.Functions.ApplicationList
 
         public static ApplicationListColors Colors => Settings.Default.MiscColorblind ? ApplicationListColors.ColorBlind : ApplicationListColors.Normal;
 
-        public static string GetApplicationStatusText(ApplicationUninstallerEntry entry)
+        public static string GetApplicationCertificateText(ApplicationUninstallerEntry entry)
         {
             if (entry == null) return Localisable.Empty;
 
-            if (Settings.Default.AdvancedHighlightSpecial)
-            {
-                if (entry.UninstallerKind == UninstallerType.WindowsFeature)
-                    return entry.UninstallerKind.GetLocalisedName();
+            if (!Settings.Default.AdvancedTestCertificates)
+                return Localisable.Empty;
 
-                if (entry.UninstallerKind == UninstallerType.StoreApp)
-                    return entry.UninstallerKind.GetLocalisedName();
+            var result = entry.IsCertificateValid(true);
+            if (!result.HasValue)
+                return "None";
 
-                if (entry.IsOrphaned)
-                    return UninstallToolsLocalisation.IsOrphaned;
-            }
+            return result.Value
+                ? GetListLegendText("labelVerified.Text", "Verified certificate")
+                : GetListLegendText("labelUnverified.Text", "Unverified certificate");
+        }
 
-            if (!entry.IsValid && Settings.Default.AdvancedTestInvalid)
-                return UninstallToolsLocalisation.UninstallStatus_Invalid;
+        public static string GetApplicationIntegrityText(ApplicationUninstallerEntry entry)
+        {
+            if (entry == null) return Localisable.Empty;
 
-            if (Settings.Default.AdvancedTestCertificates)
-            {
-                var result = entry.IsCertificateValid(true);
-                if (result.HasValue)
-                    return result.Value ? GetListLegendText("labelVerified.Text", "Verified certificate") : GetListLegendText("labelUnverified.Text", "Unverified certificate");
-            }
+            var missingRegistry = entry.IsOrphaned || !entry.IsRegistered;
+            var missingUninstaller = !entry.IsValid;
 
-            return Localisable.Empty;
+            if (missingRegistry && missingUninstaller)
+                return "Missing uninstaller and registry";
+
+            if (missingRegistry)
+                return "Missing registry";
+
+            if (missingUninstaller)
+                return GetListLegendText("labelInvalid.Text", "Missing uninstaller");
+
+            return UninstallToolsLocalisation.Confidence_Good;
         }
 
         public static Color GetApplicationBackColor(ApplicationUninstallerEntry entry)

--- a/source/BulkCrapUninstaller/Functions/ApplicationList/ApplicationListConstants.cs
+++ b/source/BulkCrapUninstaller/Functions/ApplicationList/ApplicationListConstants.cs
@@ -9,7 +9,6 @@ using System.Drawing;
 using BulkCrapUninstaller.Controls;
 using BulkCrapUninstaller.Properties;
 using UninstallTools;
-using UninstallToolsLocalisation = UninstallTools.Properties.Localisation;
 
 namespace BulkCrapUninstaller.Functions.ApplicationList
 {
@@ -51,7 +50,7 @@ namespace BulkCrapUninstaller.Functions.ApplicationList
             if (missingUninstaller)
                 return GetListLegendText("labelInvalid.Text", "Missing uninstaller");
 
-            return UninstallToolsLocalisation.Confidence_Good;
+            return "Good";
         }
 
         public static Color GetApplicationBackColor(ApplicationUninstallerEntry entry)

--- a/source/BulkCrapUninstaller/Functions/ApplicationList/ApplicationListConstants.cs
+++ b/source/BulkCrapUninstaller/Functions/ApplicationList/ApplicationListConstants.cs
@@ -5,6 +5,7 @@
 
 using System.Drawing;
 using BulkCrapUninstaller.Properties;
+using Klocman.Resources;
 using UninstallTools;
 
 namespace BulkCrapUninstaller.Functions.ApplicationList
@@ -18,13 +19,13 @@ namespace BulkCrapUninstaller.Functions.ApplicationList
             if (entry == null) return Localisable.Empty;
 
             if (!Settings.Default.AdvancedTestCertificates)
-                return "Disabled";
+                return CommonStrings.Unknown;
 
             var result = entry.IsCertificateValid(true);
             if (!result.HasValue)
-                return "None";
-
-            return result.Value ? "Verified" : "Unverified";
+                return Localisable.CertificateColumn_NotFound;
+            
+            return result.Value ? Localisable.CertificateColumn_Verified : Localisable.CertificateColumn_Unverified;
         }
 
         public static object GetApplicationIntegrityText(ApplicationUninstallerEntry entry)
@@ -35,15 +36,15 @@ namespace BulkCrapUninstaller.Functions.ApplicationList
             var missingUninstaller = !entry.IsValid;
 
             if (missingRegistry && missingUninstaller)
-                return new[] { "No uninstaller", "No registry" };
+                return new[] { Localisable.IntegrityColumn_Invalid, Localisable.IntegrityColumn_Unregistered };
 
             if (missingRegistry)
-                return "No registry";
+                return Localisable.IntegrityColumn_Unregistered;
 
             if (missingUninstaller)
-                return "No uninstaller";
+                return Localisable.IntegrityColumn_Invalid;
 
-            return "Good";
+            return Localisable.IntegrityColumn_Good;
         }
 
         public static Color GetApplicationBackColor(ApplicationUninstallerEntry entry)

--- a/source/BulkCrapUninstaller/Functions/ApplicationList/UninstallerListConfigurator.cs
+++ b/source/BulkCrapUninstaller/Functions/ApplicationList/UninstallerListConfigurator.cs
@@ -205,6 +205,9 @@ namespace BulkCrapUninstaller.Functions.ApplicationList
             _reference.olvColumnSystemComponent.AspectToStringConverter = ListViewDelegates.BoolToYesNoAspectConverter;
             _reference.olvColumnSystemComponent.GroupKeyToTitleConverter = ListViewDelegates.BoolToYesNoAspectConverter;
 
+            _reference.olvColumnStatus.AspectGetter =
+                y => ApplicationListConstants.GetApplicationStatusText(y as ApplicationUninstallerEntry);
+
             _reference.olvColumnIs64.AspectGetter =
                 y => (y as ApplicationUninstallerEntry)?.Is64Bit.GetLocalisedName();
 

--- a/source/BulkCrapUninstaller/Functions/ApplicationList/UninstallerListConfigurator.cs
+++ b/source/BulkCrapUninstaller/Functions/ApplicationList/UninstallerListConfigurator.cs
@@ -205,11 +205,10 @@ namespace BulkCrapUninstaller.Functions.ApplicationList
             _reference.olvColumnSystemComponent.AspectToStringConverter = ListViewDelegates.BoolToYesNoAspectConverter;
             _reference.olvColumnSystemComponent.GroupKeyToTitleConverter = ListViewDelegates.BoolToYesNoAspectConverter;
 
-            _reference.olvColumnCertificate.AspectGetter =
-                y => ApplicationListConstants.GetApplicationCertificateText(y as ApplicationUninstallerEntry);
+            _reference.olvColumnCertificate.AspectGetter = y => ApplicationListConstants.GetApplicationCertificateText(y as ApplicationUninstallerEntry);
 
-            _reference.olvColumnIntegrity.AspectGetter =
-                y => ApplicationListConstants.GetApplicationIntegrityText(y as ApplicationUninstallerEntry);
+            _reference.olvColumnIntegrity.AspectGetter = y => ApplicationListConstants.GetApplicationIntegrityText(y as ApplicationUninstallerEntry);
+            _reference.olvColumnIntegrity.AspectToStringConverter = x => x is string[] arr ? string.Join(", ", arr) : x?.ToString();
 
             _reference.olvColumnIs64.AspectGetter =
                 y => (y as ApplicationUninstallerEntry)?.Is64Bit.GetLocalisedName();

--- a/source/BulkCrapUninstaller/Functions/ApplicationList/UninstallerListConfigurator.cs
+++ b/source/BulkCrapUninstaller/Functions/ApplicationList/UninstallerListConfigurator.cs
@@ -205,8 +205,11 @@ namespace BulkCrapUninstaller.Functions.ApplicationList
             _reference.olvColumnSystemComponent.AspectToStringConverter = ListViewDelegates.BoolToYesNoAspectConverter;
             _reference.olvColumnSystemComponent.GroupKeyToTitleConverter = ListViewDelegates.BoolToYesNoAspectConverter;
 
-            _reference.olvColumnStatus.AspectGetter =
-                y => ApplicationListConstants.GetApplicationStatusText(y as ApplicationUninstallerEntry);
+            _reference.olvColumnCertificate.AspectGetter =
+                y => ApplicationListConstants.GetApplicationCertificateText(y as ApplicationUninstallerEntry);
+
+            _reference.olvColumnIntegrity.AspectGetter =
+                y => ApplicationListConstants.GetApplicationIntegrityText(y as ApplicationUninstallerEntry);
 
             _reference.olvColumnIs64.AspectGetter =
                 y => (y as ApplicationUninstallerEntry)?.Is64Bit.GetLocalisedName();

--- a/source/BulkCrapUninstaller/Properties/Localisable.Designer.cs
+++ b/source/BulkCrapUninstaller/Properties/Localisable.Designer.cs
@@ -61,6 +61,33 @@ namespace BulkCrapUninstaller.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Not found.
+        /// </summary>
+        internal static string CertificateColumn_NotFound {
+            get {
+                return ResourceManager.GetString("CertificateColumn_NotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unverified.
+        /// </summary>
+        internal static string CertificateColumn_Unverified {
+            get {
+                return ResourceManager.GetString("CertificateColumn_Unverified", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Verified.
+        /// </summary>
+        internal static string CertificateColumn_Verified {
+            get {
+                return ResourceManager.GetString("CertificateColumn_Verified", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Default.
         /// </summary>
         internal static string DefaultLanguage {
@@ -120,6 +147,33 @@ namespace BulkCrapUninstaller.Properties {
         internal static string GuidMissing {
             get {
                 return ResourceManager.GetString("GuidMissing", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Good.
+        /// </summary>
+        internal static string IntegrityColumn_Good {
+            get {
+                return ResourceManager.GetString("IntegrityColumn_Good", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No uninstaller.
+        /// </summary>
+        internal static string IntegrityColumn_Invalid {
+            get {
+                return ResourceManager.GetString("IntegrityColumn_Invalid", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No registry.
+        /// </summary>
+        internal static string IntegrityColumn_Unregistered {
+            get {
+                return ResourceManager.GetString("IntegrityColumn_Unregistered", resourceCulture);
             }
         }
         

--- a/source/BulkCrapUninstaller/Properties/Localisable.resx
+++ b/source/BulkCrapUninstaller/Properties/Localisable.resx
@@ -789,4 +789,22 @@ You can try disabling collision detection in the settings, but it is not recomme
   <data name="MessageBoxes_CantRenameUninstallerKind_Details" xml:space="preserve">
     <value>This uninstaller kind does not support renaming ({0}).</value>
   </data>
+  <data name="CertificateColumn_NotFound" xml:space="preserve">
+    <value>Not found</value>
+  </data>
+  <data name="CertificateColumn_Verified" xml:space="preserve">
+    <value>Verified</value>
+  </data>
+  <data name="CertificateColumn_Unverified" xml:space="preserve">
+    <value>Unverified</value>
+  </data>
+  <data name="IntegrityColumn_Invalid" xml:space="preserve">
+    <value>No uninstaller</value>
+  </data>
+  <data name="IntegrityColumn_Unregistered" xml:space="preserve">
+    <value>No registry</value>
+  </data>
+  <data name="IntegrityColumn_Good" xml:space="preserve">
+    <value>Good</value>
+  </data>
 </root>

--- a/source/BulkCrapUninstallerTests/Functions/ApplicationListConstantsTests.cs
+++ b/source/BulkCrapUninstallerTests/Functions/ApplicationListConstantsTests.cs
@@ -1,0 +1,131 @@
+using BulkCrapUninstaller.Functions.ApplicationList;
+using BulkCrapUninstaller.Properties;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using UninstallTools;
+
+namespace BulkCrapUninstallerTests.Functions
+{
+    [TestClass]
+    public class ApplicationListConstantsTests
+    {
+        private bool _advancedHighlightSpecial;
+        private bool _advancedTestInvalid;
+        private bool _advancedTestCertificates;
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            _advancedHighlightSpecial = Settings.Default.AdvancedHighlightSpecial;
+            _advancedTestInvalid = Settings.Default.AdvancedTestInvalid;
+            _advancedTestCertificates = Settings.Default.AdvancedTestCertificates;
+
+            Settings.Default.AdvancedHighlightSpecial = true;
+            Settings.Default.AdvancedTestInvalid = true;
+            Settings.Default.AdvancedTestCertificates = true;
+        }
+
+        [TestCleanup]
+        public void TestCleanup()
+        {
+            Settings.Default.AdvancedHighlightSpecial = _advancedHighlightSpecial;
+            Settings.Default.AdvancedTestInvalid = _advancedTestInvalid;
+            Settings.Default.AdvancedTestCertificates = _advancedTestCertificates;
+        }
+
+        [TestMethod]
+        public void GetApplicationStatusText_ReturnsWindowsFeatureStatus()
+        {
+            var entry = new ApplicationUninstallerEntry
+            {
+                UninstallerKind = UninstallerType.WindowsFeature,
+                IsValid = true
+            };
+
+            var result = ApplicationListConstants.GetApplicationStatusText(entry);
+
+            Assert.AreEqual(entry.UninstallerKind.GetLocalisedName(), result);
+        }
+
+        [TestMethod]
+        public void GetApplicationStatusText_ReturnsStoreAppStatus()
+        {
+            var entry = new ApplicationUninstallerEntry
+            {
+                UninstallerKind = UninstallerType.StoreApp,
+                IsValid = true
+            };
+
+            var result = ApplicationListConstants.GetApplicationStatusText(entry);
+
+            Assert.AreEqual(entry.UninstallerKind.GetLocalisedName(), result);
+        }
+
+        [TestMethod]
+        public void GetApplicationStatusText_ReturnsOrphanedStatus()
+        {
+            var entry = new ApplicationUninstallerEntry
+            {
+                IsOrphaned = true,
+                IsValid = true
+            };
+
+            var result = ApplicationListConstants.GetApplicationStatusText(entry);
+
+            Assert.AreEqual(UninstallTools.Properties.Localisation.IsOrphaned, result);
+        }
+
+        [TestMethod]
+        public void GetApplicationStatusText_ReturnsInvalidStatus()
+        {
+            var entry = new ApplicationUninstallerEntry
+            {
+                IsValid = false
+            };
+
+            var result = ApplicationListConstants.GetApplicationStatusText(entry);
+
+            Assert.AreEqual(UninstallTools.Properties.Localisation.UninstallStatus_Invalid, result);
+        }
+
+        [TestMethod]
+        public void GetApplicationStatusText_ReturnsVerifiedCertificateStatus()
+        {
+            var entry = new ApplicationUninstallerEntry
+            {
+                IsValid = true
+            };
+            entry.SetCertificate(null, true);
+
+            var result = ApplicationListConstants.GetApplicationStatusText(entry);
+
+            Assert.AreEqual("Verified certificate", result);
+        }
+
+        [TestMethod]
+        public void GetApplicationStatusText_ReturnsUnverifiedCertificateStatus()
+        {
+            var entry = new ApplicationUninstallerEntry
+            {
+                IsValid = true
+            };
+            entry.SetCertificate(null, false);
+
+            var result = ApplicationListConstants.GetApplicationStatusText(entry);
+
+            Assert.AreEqual("Unverified certificate", result);
+        }
+
+        [TestMethod]
+        public void GetApplicationStatusText_ReturnsEmptyWhenNoSpecialStateApplies()
+        {
+            var entry = new ApplicationUninstallerEntry
+            {
+                IsValid = true
+            };
+
+            var result = ApplicationListConstants.GetApplicationStatusText(entry);
+
+            Assert.AreEqual(Localisable.Empty, result);
+        }
+    }
+}

--- a/source/BulkCrapUninstallerTests/Functions/ApplicationListConstantsTests.cs
+++ b/source/BulkCrapUninstallerTests/Functions/ApplicationListConstantsTests.cs
@@ -8,87 +8,36 @@ namespace BulkCrapUninstallerTests.Functions
     [TestClass]
     public class ApplicationListConstantsTests
     {
-        private bool _advancedHighlightSpecial;
-        private bool _advancedTestInvalid;
         private bool _advancedTestCertificates;
 
         [TestInitialize]
         public void TestInitialize()
         {
-            _advancedHighlightSpecial = Settings.Default.AdvancedHighlightSpecial;
-            _advancedTestInvalid = Settings.Default.AdvancedTestInvalid;
             _advancedTestCertificates = Settings.Default.AdvancedTestCertificates;
-
-            Settings.Default.AdvancedHighlightSpecial = true;
-            Settings.Default.AdvancedTestInvalid = true;
             Settings.Default.AdvancedTestCertificates = true;
         }
 
         [TestCleanup]
         public void TestCleanup()
         {
-            Settings.Default.AdvancedHighlightSpecial = _advancedHighlightSpecial;
-            Settings.Default.AdvancedTestInvalid = _advancedTestInvalid;
             Settings.Default.AdvancedTestCertificates = _advancedTestCertificates;
         }
 
         [TestMethod]
-        public void GetApplicationStatusText_ReturnsWindowsFeatureStatus()
+        public void GetApplicationCertificateText_ReturnsNoneWhenCertificateIsMissing()
         {
             var entry = new ApplicationUninstallerEntry
             {
-                UninstallerKind = UninstallerType.WindowsFeature,
                 IsValid = true
             };
 
-            var result = ApplicationListConstants.GetApplicationStatusText(entry);
+            var result = ApplicationListConstants.GetApplicationCertificateText(entry);
 
-            Assert.AreEqual(entry.UninstallerKind.GetLocalisedName(), result);
+            Assert.AreEqual("None", result);
         }
 
         [TestMethod]
-        public void GetApplicationStatusText_ReturnsStoreAppStatus()
-        {
-            var entry = new ApplicationUninstallerEntry
-            {
-                UninstallerKind = UninstallerType.StoreApp,
-                IsValid = true
-            };
-
-            var result = ApplicationListConstants.GetApplicationStatusText(entry);
-
-            Assert.AreEqual(entry.UninstallerKind.GetLocalisedName(), result);
-        }
-
-        [TestMethod]
-        public void GetApplicationStatusText_ReturnsOrphanedStatus()
-        {
-            var entry = new ApplicationUninstallerEntry
-            {
-                IsOrphaned = true,
-                IsValid = true
-            };
-
-            var result = ApplicationListConstants.GetApplicationStatusText(entry);
-
-            Assert.AreEqual(UninstallTools.Properties.Localisation.IsOrphaned, result);
-        }
-
-        [TestMethod]
-        public void GetApplicationStatusText_ReturnsInvalidStatus()
-        {
-            var entry = new ApplicationUninstallerEntry
-            {
-                IsValid = false
-            };
-
-            var result = ApplicationListConstants.GetApplicationStatusText(entry);
-
-            Assert.AreEqual(UninstallTools.Properties.Localisation.UninstallStatus_Invalid, result);
-        }
-
-        [TestMethod]
-        public void GetApplicationStatusText_ReturnsVerifiedCertificateStatus()
+        public void GetApplicationCertificateText_ReturnsVerifiedCertificateStatus()
         {
             var entry = new ApplicationUninstallerEntry
             {
@@ -96,13 +45,13 @@ namespace BulkCrapUninstallerTests.Functions
             };
             entry.SetCertificate(null, true);
 
-            var result = ApplicationListConstants.GetApplicationStatusText(entry);
+            var result = ApplicationListConstants.GetApplicationCertificateText(entry);
 
             Assert.AreEqual("Verified certificate", result);
         }
 
         [TestMethod]
-        public void GetApplicationStatusText_ReturnsUnverifiedCertificateStatus()
+        public void GetApplicationCertificateText_ReturnsUnverifiedCertificateStatus()
         {
             var entry = new ApplicationUninstallerEntry
             {
@@ -110,22 +59,94 @@ namespace BulkCrapUninstallerTests.Functions
             };
             entry.SetCertificate(null, false);
 
-            var result = ApplicationListConstants.GetApplicationStatusText(entry);
+            var result = ApplicationListConstants.GetApplicationCertificateText(entry);
 
             Assert.AreEqual("Unverified certificate", result);
         }
 
         [TestMethod]
-        public void GetApplicationStatusText_ReturnsEmptyWhenNoSpecialStateApplies()
+        public void GetApplicationCertificateText_ReturnsEmptyWhenCertificateChecksAreDisabled()
         {
             var entry = new ApplicationUninstallerEntry
             {
                 IsValid = true
             };
+            Settings.Default.AdvancedTestCertificates = false;
 
-            var result = ApplicationListConstants.GetApplicationStatusText(entry);
+            var result = ApplicationListConstants.GetApplicationCertificateText(entry);
 
             Assert.AreEqual(Localisable.Empty, result);
+        }
+
+        [TestMethod]
+        public void GetApplicationIntegrityText_ReturnsGoodWhenEntryIsRegisteredAndValid()
+        {
+            var entry = new ApplicationUninstallerEntry
+            {
+                IsRegistered = true,
+                IsValid = true
+            };
+
+            var result = ApplicationListConstants.GetApplicationIntegrityText(entry);
+
+            Assert.AreEqual(UninstallTools.Properties.Localisation.Confidence_Good, result);
+        }
+
+        [TestMethod]
+        public void GetApplicationIntegrityText_ReturnsMissingUninstallerWhenEntryIsInvalid()
+        {
+            var entry = new ApplicationUninstallerEntry
+            {
+                IsRegistered = true,
+                IsValid = false
+            };
+
+            var result = ApplicationListConstants.GetApplicationIntegrityText(entry);
+
+            Assert.AreEqual("Missing uninstaller", result);
+        }
+
+        [TestMethod]
+        public void GetApplicationIntegrityText_ReturnsMissingRegistryWhenEntryIsUnregistered()
+        {
+            var entry = new ApplicationUninstallerEntry
+            {
+                IsRegistered = false,
+                IsValid = true
+            };
+
+            var result = ApplicationListConstants.GetApplicationIntegrityText(entry);
+
+            Assert.AreEqual("Missing registry", result);
+        }
+
+        [TestMethod]
+        public void GetApplicationIntegrityText_ReturnsMissingRegistryWhenEntryIsOrphaned()
+        {
+            var entry = new ApplicationUninstallerEntry
+            {
+                IsRegistered = true,
+                IsOrphaned = true,
+                IsValid = true
+            };
+
+            var result = ApplicationListConstants.GetApplicationIntegrityText(entry);
+
+            Assert.AreEqual("Missing registry", result);
+        }
+
+        [TestMethod]
+        public void GetApplicationIntegrityText_ReturnsMissingRegistryAndUninstallerWhenBothAreMissing()
+        {
+            var entry = new ApplicationUninstallerEntry
+            {
+                IsRegistered = false,
+                IsValid = false
+            };
+
+            var result = ApplicationListConstants.GetApplicationIntegrityText(entry);
+
+            Assert.AreEqual("Missing uninstaller and registry", result);
         }
     }
 }

--- a/source/BulkCrapUninstallerTests/Functions/ApplicationListConstantsTests.cs
+++ b/source/BulkCrapUninstallerTests/Functions/ApplicationListConstantsTests.cs
@@ -1,5 +1,6 @@
 using BulkCrapUninstaller.Functions.ApplicationList;
 using BulkCrapUninstaller.Properties;
+using Klocman.Resources;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using UninstallTools;
 
@@ -33,7 +34,7 @@ namespace BulkCrapUninstallerTests.Functions
 
             var result = ApplicationListConstants.GetApplicationCertificateText(entry);
 
-            Assert.AreEqual("None", result);
+            Assert.AreEqual(Localisable.CertificateColumn_NotFound, result);
         }
 
         [TestMethod]
@@ -47,7 +48,7 @@ namespace BulkCrapUninstallerTests.Functions
 
             var result = ApplicationListConstants.GetApplicationCertificateText(entry);
 
-            Assert.AreEqual("Verified certificate", result);
+            Assert.AreEqual(Localisable.CertificateColumn_Verified, result);
         }
 
         [TestMethod]
@@ -61,7 +62,7 @@ namespace BulkCrapUninstallerTests.Functions
 
             var result = ApplicationListConstants.GetApplicationCertificateText(entry);
 
-            Assert.AreEqual("Unverified certificate", result);
+            Assert.AreEqual(Localisable.CertificateColumn_Unverified, result);
         }
 
         [TestMethod]
@@ -75,7 +76,7 @@ namespace BulkCrapUninstallerTests.Functions
 
             var result = ApplicationListConstants.GetApplicationCertificateText(entry);
 
-            Assert.AreEqual(Localisable.Empty, result);
+            Assert.AreEqual(CommonStrings.Unknown, result);
         }
 
         [TestMethod]
@@ -103,7 +104,7 @@ namespace BulkCrapUninstallerTests.Functions
 
             var result = ApplicationListConstants.GetApplicationIntegrityText(entry);
 
-            Assert.AreEqual("Missing uninstaller", result);
+            Assert.AreEqual(Localisable.IntegrityColumn_Invalid, result);
         }
 
         [TestMethod]
@@ -117,7 +118,7 @@ namespace BulkCrapUninstallerTests.Functions
 
             var result = ApplicationListConstants.GetApplicationIntegrityText(entry);
 
-            Assert.AreEqual("Missing registry", result);
+            Assert.AreEqual(Localisable.IntegrityColumn_Unregistered, result);
         }
 
         [TestMethod]
@@ -132,7 +133,7 @@ namespace BulkCrapUninstallerTests.Functions
 
             var result = ApplicationListConstants.GetApplicationIntegrityText(entry);
 
-            Assert.AreEqual("Missing registry", result);
+            Assert.AreEqual(Localisable.IntegrityColumn_Unregistered, result);
         }
 
         [TestMethod]
@@ -146,7 +147,7 @@ namespace BulkCrapUninstallerTests.Functions
 
             var result = ApplicationListConstants.GetApplicationIntegrityText(entry);
 
-            Assert.AreEqual("Missing uninstaller and registry", result);
+            CollectionAssert.AreEqual(new[] { Localisable.IntegrityColumn_Invalid, Localisable.IntegrityColumn_Unregistered }, (object[])result);
         }
     }
 }


### PR DESCRIPTION
Closes #814

## Summary

This PR adds two explicit text columns to the app list:
- `Certificate`
- `Integrity`

## Changes

- replace the previous single `Status` column approach
- add a `Certificate` column with `None` / `Unverified` / `Verified`
- add an `Integrity` column with:
  - `Good`
  - `Missing uninstaller`
  - `Missing registry`
  - `Missing uninstaller and registry`
- keep the existing background-color logic unchanged
- add regression tests for both column value generators