### PR TITLE
Improve uninstall list load error handling

### DIFF
--- a/source/BulkCrapUninstaller/Controls/Settings/AdvancedFilters.cs
+++ b/source/BulkCrapUninstaller/Controls/Settings/AdvancedFilters.cs
@@ -116,8 +116,8 @@ namespace BulkCrapUninstaller.Controls
             }
             catch (Exception ex)
             {
-                PremadeDialogs.GenericError("File is not an uninstall list or it can't be opened",
-                    "Please note that uninstall lists are saved in the \"Advanced filtering\" view, not by exporting. Lists should have the .bcul extension.\n\nError message: " + ex.Message);
+                MessageBoxes.OpenUninstallListError(
+                    Localisable.MessageBoxes_Error_details + ex.Message);
             }
         }
 

--- a/source/BulkCrapUninstallerTests/UninstallListTests.cs
+++ b/source/BulkCrapUninstallerTests/UninstallListTests.cs
@@ -1,0 +1,54 @@
+using System.IO;
+using System.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using UninstallTools.Lists;
+
+namespace BulkCrapUninstallerTests
+{
+    [TestClass]
+    public class UninstallListTests
+    {
+        [TestMethod]
+        public void ReadFromFile_EmptyFile_ThrowsInvalidDataException()
+        {
+            var path = Path.GetTempFileName();
+            try
+            {
+                File.WriteAllText(path, string.Empty);
+
+                var ex = Assert.ThrowsException<InvalidDataException>(() => UninstallList.ReadFromFile(path));
+
+                StringAssert.Contains(ex.Message, "empty");
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        [TestMethod]
+        public void ReadFromFile_LeadingBomAndWhitespace_LoadsList()
+        {
+            var path = Path.GetTempFileName();
+            try
+            {
+                var input = new UninstallList(new[] { new Filter("Test", "Example App") });
+                input.SaveToFile(path);
+
+                var originalContents = File.ReadAllText(path);
+                File.WriteAllText(path, "\uFEFF\r\n\t  " + originalContents, Encoding.UTF8);
+
+                var result = UninstallList.ReadFromFile(path);
+
+                Assert.IsNotNull(result);
+                Assert.AreEqual(1, result.Filters.Count);
+                Assert.AreEqual("Test", result.Filters[0].Name);
+                Assert.AreEqual("Example App", result.Filters[0].ComparisonEntries[0].FilterText);
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+    }
+}

--- a/source/UninstallTools/Lists/UninstallList.cs
+++ b/source/UninstallTools/Lists/UninstallList.cs
@@ -3,7 +3,9 @@
     Apache License Version 2.0
 */
 
+using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Xml;
@@ -13,6 +15,14 @@ namespace UninstallTools.Lists
 {
     public class UninstallList : ITestEntry
     {
+        private static readonly XmlReaderSettings ReaderSettings = new()
+        {
+            CloseInput = false,
+            DtdProcessing = DtdProcessing.Prohibit,
+            IgnoreComments = true,
+            IgnoreWhitespace = true
+        };
+
         public UninstallList()
         {
         }
@@ -73,10 +83,40 @@ namespace UninstallTools.Lists
 
         public static UninstallList ReadFromFile(string fileName)
         {
+            if (string.IsNullOrWhiteSpace(fileName))
+                throw new ArgumentException("File name cannot be empty.", nameof(fileName));
+
             var serializer = new XmlSerializer(typeof (UninstallList));
-            using (var reader = new XmlTextReader(fileName))
+            using (var stream = File.OpenRead(fileName))
             {
-                return serializer.Deserialize(reader) as UninstallList;
+                if (stream.Length == 0)
+                    throw new InvalidDataException("The uninstall list file is empty.");
+
+                try
+                {
+                    return Deserialize(serializer, XmlReader.Create(stream, ReaderSettings));
+                }
+                catch (Exception ex) when (ex is InvalidOperationException or XmlException)
+                {
+                    if (!stream.CanSeek)
+                        throw CreateInvalidDataException(ex);
+
+                    stream.Position = 0;
+                    using var textReader = new StreamReader(stream, Encoding.UTF8, true, 1024, true);
+                    var trimmedContents = textReader.ReadToEnd().TrimStart('\uFEFF', '\u200B', ' ', '\t', '\r', '\n');
+                    if (trimmedContents.Length == 0)
+                        throw CreateInvalidDataException(ex);
+
+                    using var stringReader = new StringReader(trimmedContents);
+                    try
+                    {
+                        return Deserialize(serializer, XmlReader.Create(stringReader, ReaderSettings));
+                    }
+                    catch (Exception retryEx) when (retryEx is InvalidOperationException or XmlException)
+                    {
+                        throw CreateInvalidDataException(retryEx);
+                    }
+                }
             }
         }
 
@@ -109,6 +149,40 @@ namespace UninstallTools.Lists
         {
             if (Filters.Contains(item))
                 Filters.Remove(item);
+        }
+
+        private static UninstallList Deserialize(XmlSerializer serializer, XmlReader reader)
+        {
+            using (reader)
+            {
+                reader.MoveToContent();
+                if (reader.NodeType != XmlNodeType.Element ||
+                    !string.Equals(reader.LocalName, nameof(UninstallList), StringComparison.Ordinal))
+                {
+                    throw new InvalidDataException(
+                        $"The file does not contain an uninstall list. Expected root element '{nameof(UninstallList)}' but found '{reader.LocalName}'.");
+                }
+
+                var result = serializer.Deserialize(reader) as UninstallList;
+                if (result == null)
+                    throw new InvalidDataException("The uninstall list file could not be deserialized.");
+
+                result.Filters ??= new List<Filter>();
+                return result;
+            }
+        }
+
+        private static InvalidDataException CreateInvalidDataException(Exception ex)
+        {
+            var xmlException = ex as XmlException ?? ex.InnerException as XmlException;
+            if (xmlException != null)
+            {
+                return new InvalidDataException(
+                    $"The uninstall list XML is invalid at line {xmlException.LineNumber}, position {xmlException.LinePosition}: {xmlException.Message}",
+                    ex);
+            }
+
+            return new InvalidDataException("The uninstall list file is not valid XML.", ex);
         }
     }
 }


### PR DESCRIPTION
## Summary

This PR makes `.bcul` uninstall list loading more robust and improves the error shown when loading fails.

## Changes

- reject empty uninstall list files with a clear error
- handle leading BOM / whitespace before the XML root element
- validate the expected root element before deserializing
- convert generic XML deserialization failures into more useful messages with line/position details when available
- show the improved error through the existing uninstall-list error dialog
- add tests for empty files and BOM-prefixed valid lists

## Why

Users currently get generic errors like `There is an error in XML document (0, 0)` when opening some uninstall list files. This change makes common failure modes easier to diagnose and avoids failing on benign leading BOM/whitespace cases.

Closes #816
