### PR TITLE
Harden BCU console export and size detection - Fix BCU-console export failures

### DIFF
--- a/source/BulkCrapUninstallerTests/ApplicationEntrySerializerTests.cs
+++ b/source/BulkCrapUninstallerTests/ApplicationEntrySerializerTests.cs
@@ -1,0 +1,44 @@
+using System.IO;
+using Klocman.Tools;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using UninstallTools;
+
+namespace BulkCrapUninstallerTests
+{
+    [TestClass]
+    public class ApplicationEntrySerializerTests
+    {
+        [TestMethod]
+        public void SerializeApplicationEntries_InvalidXmlCharactersAreRemoved_ValidUnicodeIsPreserved()
+        {
+            var path = Path.GetTempFileName();
+            try
+            {
+                var entry = new ApplicationUninstallerEntry
+                {
+                    DisplayName = "Test app",
+                    Publisher = "Pu\u0002blisher",
+                    Comment = "Before\u0001after \U0001F600",
+                    CacheIdOverride = "Id\u0003value"
+                };
+
+                ApplicationEntrySerializer.SerializeApplicationEntries(path, new[] { entry });
+
+                var result = SerializationTools.DeserializeFromXml<ApplicationEntrySerializer>(path);
+
+                Assert.IsNotNull(result);
+                Assert.AreEqual(1, result.Items.Count);
+                Assert.AreEqual("Publisher", result.Items[0].Publisher);
+                Assert.AreEqual("Beforeafter \U0001F600", result.Items[0].Comment);
+                Assert.AreEqual("Idvalue", result.Items[0].CacheIdOverride);
+                Assert.AreEqual("Pu\u0002blisher", entry.Publisher);
+                Assert.AreEqual("Before\u0001after \U0001F600", entry.Comment);
+                Assert.AreEqual("Id\u0003value", entry.CacheIdOverride);
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+    }
+}

--- a/source/KlocTools/Tools/SerializationTools.cs
+++ b/source/KlocTools/Tools/SerializationTools.cs
@@ -7,12 +7,40 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Xml.Serialization;
 
 namespace Klocman.Tools
 {
     public static class SerializationTools
     {
+        public static string SanitizeInvalidXmlCharacters(string input)
+        {
+            if (string.IsNullOrEmpty(input))
+                return input;
+
+            StringBuilder output = null;
+            var consumedUtf16Chars = 0;
+
+            foreach (var rune in input.EnumerateRunes())
+            {
+                if (IsValidXmlCharacter(rune))
+                {
+                    output?.Append(rune.ToString());
+                }
+                else
+                {
+                    output ??= new StringBuilder(input.Length);
+                    if (consumedUtf16Chars > 0 && output.Length == 0)
+                        output.Append(input, 0, consumedUtf16Chars);
+                }
+
+                consumedUtf16Chars += rune.Utf16SequenceLength;
+            }
+
+            return output?.ToString() ?? input;
+        }
+
         public static T DeserializeFromXml<T>(string fullFilename)
         {
             var serializer = new XmlSerializer(typeof(T));
@@ -59,6 +87,16 @@ namespace Klocman.Tools
 
             public TValue Data { get; set; }
             public TKey Key { get; set; }
+        }
+
+        private static bool IsValidXmlCharacter(Rune value)
+        {
+            return value.Value == 0x9 ||
+                   value.Value == 0xA ||
+                   value.Value == 0xD ||
+                   (value.Value >= 0x20 && value.Value <= 0xD7FF) ||
+                   (value.Value >= 0xE000 && value.Value <= 0xFFFD) ||
+                   (value.Value >= 0x10000 && value.Value <= 0x10FFFF);
         }
     }
 }

--- a/source/UninstallTools/ApplicationEntrySerializer.cs
+++ b/source/UninstallTools/ApplicationEntrySerializer.cs
@@ -5,15 +5,33 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using Klocman.Tools;
 
 namespace UninstallTools
 {
     public sealed class ApplicationEntrySerializer
     {
+        private static readonly PropertyInfo[] SanitizableProperties = typeof(ApplicationUninstallerEntry)
+            .GetProperties(BindingFlags.Instance | BindingFlags.Public)
+            .Where(x => x.CanRead && x.CanWrite && x.GetIndexParameters().Length == 0 &&
+                        (x.PropertyType == typeof(string) || x.PropertyType == typeof(string[])))
+            .ToArray();
+        private static readonly MethodInfo MemberwiseCloneMethod = typeof(object)
+            .GetMethod("MemberwiseClone", BindingFlags.Instance | BindingFlags.NonPublic);
+
+        private static readonly FieldInfo[] SanitizableFields = typeof(ApplicationUninstallerEntry)
+            .GetFields(BindingFlags.Instance | BindingFlags.Public)
+            .Where(x => x.FieldType == typeof(string) || x.FieldType == typeof(string[]))
+            .ToArray();
+
         public static void SerializeApplicationEntries(string filename, IEnumerable<ApplicationUninstallerEntry> items)
         {
-            SerializationTools.SerializeToXml(filename, new ApplicationEntrySerializer(items));
+            var sanitizedItems = items?
+                .Select(CloneAndSanitizeForXmlExport)
+                .ToList() ?? new List<ApplicationUninstallerEntry>();
+
+            SerializationTools.SerializeToXml(filename, new ApplicationEntrySerializer(sanitizedItems));
         }
 
         public ApplicationEntrySerializer(IEnumerable<ApplicationUninstallerEntry> items)
@@ -27,5 +45,66 @@ namespace UninstallTools
         }
 
         public List<ApplicationUninstallerEntry> Items { get; set; }
+
+        private static ApplicationUninstallerEntry CloneAndSanitizeForXmlExport(ApplicationUninstallerEntry item)
+        {
+            if (item == null)
+                return null;
+
+            var clone = (ApplicationUninstallerEntry)MemberwiseCloneMethod.Invoke(item, null);
+            SanitizeForXmlExport(clone);
+            return clone;
+        }
+
+        private static void SanitizeForXmlExport(ApplicationUninstallerEntry item)
+        {
+            foreach (var property in SanitizableProperties)
+            {
+                if (property.PropertyType == typeof(string))
+                {
+                    var currentValue = property.GetValue(item) as string;
+                    var sanitizedValue = SerializationTools.SanitizeInvalidXmlCharacters(currentValue);
+                    if (!string.Equals(currentValue, sanitizedValue, System.StringComparison.Ordinal))
+                        property.SetValue(item, sanitizedValue);
+                }
+                else if (property.PropertyType == typeof(string[]))
+                {
+                    var currentValue = property.GetValue(item) as string[];
+                    if (currentValue == null)
+                        continue;
+
+                    var sanitizedValue = currentValue
+                        .Select(SerializationTools.SanitizeInvalidXmlCharacters)
+                        .ToArray();
+
+                    if (!currentValue.SequenceEqual(sanitizedValue, System.StringComparer.Ordinal))
+                        property.SetValue(item, sanitizedValue);
+                }
+            }
+
+            foreach (var field in SanitizableFields)
+            {
+                if (field.FieldType == typeof(string))
+                {
+                    var currentValue = field.GetValue(item) as string;
+                    var sanitizedValue = SerializationTools.SanitizeInvalidXmlCharacters(currentValue);
+                    if (!string.Equals(currentValue, sanitizedValue, System.StringComparison.Ordinal))
+                        field.SetValue(item, sanitizedValue);
+                }
+                else if (field.FieldType == typeof(string[]))
+                {
+                    var currentValue = field.GetValue(item) as string[];
+                    if (currentValue == null)
+                        continue;
+
+                    var sanitizedValue = currentValue
+                        .Select(SerializationTools.SanitizeInvalidXmlCharacters)
+                        .ToArray();
+
+                    if (!currentValue.SequenceEqual(sanitizedValue, System.StringComparer.Ordinal))
+                        field.SetValue(item, sanitizedValue);
+                }
+            }
+        }
     }
 }

--- a/source/UninstallTools/Factory/InfoAdders/FastSizeGenerator.cs
+++ b/source/UninstallTools/Factory/InfoAdders/FastSizeGenerator.cs
@@ -38,7 +38,7 @@ namespace UninstallTools.Factory.InfoAdders
 
                 _everythingAvailable = true;
             }
-            catch (SystemException ex)
+            catch (Exception ex)
             {
                 _everythingAvailable = false;
                 Trace.WriteLine(@"FastSizeGenerator: Everything search engine is not available - " + ex.Message);
@@ -103,7 +103,7 @@ namespace UninstallTools.Factory.InfoAdders
             {
                 UseShellExecute = false,
                 RedirectStandardOutput = true,
-                RedirectStandardError = false,
+                RedirectStandardError = true,
                 CreateNoWindow = true,
                 StandardOutputEncoding = Encoding.UTF8
             }))
@@ -112,6 +112,7 @@ namespace UninstallTools.Factory.InfoAdders
 
                 var timeoutTask = Task.Delay(TimeSpan.FromSeconds(40));
                 var readOutputTask = process.StandardOutput.ReadToEndAsync();
+                var readErrorTask = process.StandardError.ReadToEndAsync();
 
                 await Task.WhenAny(readOutputTask, timeoutTask);
 
@@ -128,8 +129,16 @@ namespace UninstallTools.Factory.InfoAdders
                     throw new TimeoutException("es.exe appears to have hung");
                 }
 
-                if (process.ExitCode == 0) return await readOutputTask;
-                throw new IOException("es.exe failed to connect to Everything", process.ExitCode);
+                var output = await readOutputTask;
+                var errorOutput = await readErrorTask;
+                process.WaitForExit();
+
+                if (process.ExitCode == 0) return output;
+
+                var message = string.IsNullOrWhiteSpace(errorOutput)
+                    ? "es.exe failed to connect to Everything"
+                    : "es.exe failed to connect to Everything: " + errorOutput.Trim();
+                throw new IOException(message, process.ExitCode);
             }
         }
 


### PR DESCRIPTION
## Summary

This PR hardens two BCU-console related failure paths.

## Fixes

- handle Everything / `es.exe` availability failures more defensively when estimating sizes
- prevent XML export from failing when application metadata contains invalid XML characters

## Changes

- catch broader startup failures in `FastSizeGenerator` so missing/broken Everything integration degrades gracefully
- capture stderr from `es.exe` and surface a more useful error message on failure
- sanitize invalid XML characters before serializing exported application entries
- avoid mutating the original in-memory entries by sanitizing cloned export objects
- add a regression test covering invalid XML characters and valid Unicode preservation

## Why

Two open issues report:
- noisy or unexpected failures when Everything is unavailable
- export crashes such as `hexadecimal value 0x1F, is an invalid character`

This change keeps export working and makes size-detection fallback behavior safer.

Closes #879
Closes #880
