### PR TITLE
Fix tweak visibility filtering

### DIFF
--- a/source/BulkCrapUninstaller/Forms/Windows/MainWindow.cs
+++ b/source/BulkCrapUninstaller/Forms/Windows/MainWindow.cs
@@ -1419,7 +1419,7 @@ namespace BulkCrapUninstaller.Forms
             _anySysComponents = _listView.AllUninstallers.Any(x => x.SystemComponent);
             _anyUpdates = _listView.AllUninstallers.Any(x => x.IsUpdate);
             _anyInvalid = _listView.AllUninstallers.Any(x => !x.IsValid);
-            _anyTweaks = _listView.AllUninstallers.Any(x => x.RatingId != null && x.RatingId.StartsWith("tweak", StringComparison.OrdinalIgnoreCase));
+            _anyTweaks = _listView.AllUninstallers.Any(x => x.IsScriptTweak);
 
             propertiesSidebar.StoreAppsEnabled = _anyStoreApps;
             propertiesSidebar.WinFeaturesEnabled = _anyWinFeatures;
@@ -1859,7 +1859,7 @@ namespace BulkCrapUninstaller.Forms
         private void viewTweaksToolStripMenuItem_Click(object sender, EventArgs e)
         {
             everythingToolStripMenuItem_Click(sender, e);
-            filterEditor1.Search(@"\Resources\Scripts\Tweak", ComparisonMethod.Contains, nameof(ApplicationUninstallerEntry.UninstallString));
+            filterEditor1.Search(true.ToString(), ComparisonMethod.Equals, nameof(ApplicationUninstallerEntry.IsScriptTweak));
         }
 
         private void createRestorePointToolStripMenuItem_Click(object sender, EventArgs e)

--- a/source/BulkCrapUninstaller/Functions/ApplicationList/UninstallerListConfigurator.cs
+++ b/source/BulkCrapUninstaller/Functions/ApplicationList/UninstallerListConfigurator.cs
@@ -111,10 +111,9 @@ namespace BulkCrapUninstaller.Functions.ApplicationList
                 results.Add(new Filter("Updates", true, new FilterCondition(true.ToString(),
                     ComparisonMethod.Equals, nameof(ApplicationUninstallerEntry.IsUpdate))));
 
-            // TODO Better detection, can lead to bugs down the line
             if (!_settings.Settings.FilterShowTweaks)
-                results.Add(new Filter("Tweaks", true, new FilterCondition(@"\Resources\Scripts\Tweak",
-                    ComparisonMethod.Contains, nameof(ApplicationUninstallerEntry.UninstallString))));
+                results.Add(new Filter("Tweaks", true, new FilterCondition(true.ToString(),
+                    ComparisonMethod.Equals, nameof(ApplicationUninstallerEntry.IsScriptTweak))));
 
             return results;
         }
@@ -143,11 +142,8 @@ namespace BulkCrapUninstaller.Functions.ApplicationList
 
             if (!_settings.Settings.FilterShowUpdates && entry.IsUpdate) return false;
 
-            if (entry.RatingId != null)
-            {
-                if (!_settings.Settings.FilterShowTweaks && entry.RatingId.StartsWith("tweak", StringComparison.Ordinal))
-                    return false;
-            }
+            if (!_settings.Settings.FilterShowTweaks && entry.IsScriptTweak)
+                return false;
 
             if (string.IsNullOrEmpty(_filteringFilterCondition.FilterText)) return true;
 

--- a/source/BulkCrapUninstallerTests/ApplicationUninstallerEntryTests.cs
+++ b/source/BulkCrapUninstallerTests/ApplicationUninstallerEntryTests.cs
@@ -1,0 +1,24 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using UninstallTools;
+
+namespace BulkCrapUninstallerTests
+{
+    [TestClass]
+    public class ApplicationUninstallerEntryTests
+    {
+        [DataTestMethod]
+        [DataRow("Tweak-TestEntry", true)]
+        [DataRow("tweak-TestEntry", true)]
+        [DataRow("Steam App 42", false)]
+        [DataRow(null, false)]
+        public void IsScriptTweak_MatchesCurrentTweakIdFormat(string ratingId, bool expected)
+        {
+            var entry = new ApplicationUninstallerEntry
+            {
+                RatingId = ratingId
+            };
+
+            Assert.AreEqual(expected, entry.IsScriptTweak);
+        }
+    }
+}

--- a/source/UninstallTools/ApplicationUninstallerEntry.cs
+++ b/source/UninstallTools/ApplicationUninstallerEntry.cs
@@ -181,6 +181,11 @@ namespace UninstallTools
         [LocalisedName(typeof(Localisation), nameof(Localisation.IsUpdate))]
         public bool IsUpdate { get; set; }
 
+        [XmlIgnore]
+        [ComparisonTarget]
+        public bool IsScriptTweak => !string.IsNullOrEmpty(RatingId) &&
+                                     RatingId.StartsWith("Tweak-", StringComparison.OrdinalIgnoreCase);
+
         /// <summary>
         ///     True if the application can be uninstalled. False if the uninstaller is missing or is otherwise invalid.
         /// </summary>


### PR DESCRIPTION
Closes #867

## Summary

This PR fixes tweak visibility/filtering so "Show tweaks" and related list filtering use the same detection logic.

## Changes

- add a single `IsScriptTweak` property to `ApplicationUninstallerEntry`
- use that property in the main list filtering logic
- use that property for the "View tweaks" command
- use that property when checking whether any tweaks are present
- add a regression test for tweak ID detection

## Why

Tweak entries currently use `RatingId = "Tweak-..."`, but different parts of the UI were using inconsistent detection logic:
- one place checked tweak IDs case-insensitively
- another checked them case-sensitively
- another still relied on an old uninstall-string path pattern

Because of that, tweaks could stay visible even when "Show tweaks" was disabled.

## Result

Tweaks are now detected consistently across:
- sidebar visibility
- basic filtering
- "View tweaks"
- equivalent filter generation
