### PR TITLE
Fix orphaned-only view preset

### DIFF
--- a/source/BulkCrapUninstaller/Forms/Windows/MainWindow.cs
+++ b/source/BulkCrapUninstaller/Forms/Windows/MainWindow.cs
@@ -1684,6 +1684,7 @@ namespace BulkCrapUninstaller.Forms
 
         private void viewUnregisteredToolStripMenuItem_Click(object sender, EventArgs e)
         {
+            everythingToolStripMenuItem_Click(sender, e);
             _setMan.Selected.Settings.AdvancedDisplayOrphans = true;
             filterEditor1.Search(true.ToString(), ComparisonMethod.Equals, nameof(ApplicationUninstallerEntry.IsOrphaned));
         }


### PR DESCRIPTION
Closes #862

## Summary

This PR fixes the "View unregistered" preset so orphaned entries are shown even when they are also marked as system/protected entries.

## Changes

- update the "View unregistered" action to start from the "Everything" preset
- then apply the `IsOrphaned == true` search filter

## Why

Some orphaned MSI uninstallers can also be classified as system components or protected items.
Previously, the "View unregistered" action only enabled orphan display, but could still leave other hiding filters active.
That made orphaned entries disappear from the dedicated orphaned view.

## Result

Using "View unregistered" now reliably shows orphaned entries regardless of the other basic visibility filters.
