### PR TITLE
Detect self leftovers for the current BCU install

### DIFF
--- a/source/BulkCrapUninstallerTests/JunkManagerTests.cs
+++ b/source/BulkCrapUninstallerTests/JunkManagerTests.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using UninstallTools;
+using UninstallTools.Junk;
+using UninstallTools.Junk.Containers;
+using UninstallTools.Junk.Finders.Misc;
+
+namespace BulkCrapUninstallerTests
+{
+    [TestClass]
+    public class JunkManagerTests
+    {
+        [TestMethod]
+        public void IsCurrentApplicationInstallation_ReturnsTrueForParentInstallLocation()
+        {
+            var parentDirectory = Directory.GetParent(UninstallToolsGlobalConfig.AppLocation);
+            var target = new ApplicationUninstallerEntry
+            {
+                InstallLocation = parentDirectory?.FullName ?? UninstallToolsGlobalConfig.AppLocation
+            };
+
+            Assert.IsTrue(JunkManager.IsCurrentApplicationInstallation(target));
+        }
+
+        [TestMethod]
+        public void ShouldKeepSelfJunkResult_ReturnsFalseForDifferentApplication()
+        {
+            var foreignInstallLocation = CreateTempDirectory();
+
+            try
+            {
+                var foreignApplication = new ApplicationUninstallerEntry
+                {
+                    RawDisplayName = "Other app",
+                    InstallLocation = foreignInstallLocation
+                };
+
+                var junk = new FileSystemJunk(new DirectoryInfo(UninstallToolsGlobalConfig.AppLocation), foreignApplication, DummyJunkCreator.Instance);
+
+                Assert.IsFalse(JunkManager.ShouldKeepSelfJunkResult(junk));
+            }
+            finally
+            {
+                CleanupDirectory(foreignInstallLocation);
+            }
+        }
+
+        [TestMethod]
+        public void ShouldKeepSelfJunkResult_ReturnsTrueForCurrentApplication()
+        {
+            var currentApplication = new ApplicationUninstallerEntry
+            {
+                RawDisplayName = "Bulk Crap Uninstaller",
+                InstallLocation = UninstallToolsGlobalConfig.AppLocation
+            };
+
+            var junk = new FileSystemJunk(new DirectoryInfo(UninstallToolsGlobalConfig.AppLocation), currentApplication, DummyJunkCreator.Instance);
+
+            Assert.IsTrue(JunkManager.ShouldKeepSelfJunkResult(junk));
+        }
+
+        [TestMethod]
+        public void ShouldKeepShortcutTarget_AllowsCurrentApplicationShortcuts()
+        {
+            var shortcutTarget = Path.Combine(UninstallToolsGlobalConfig.AppLocation, "BCUninstaller.exe");
+            var currentApplication = new ApplicationUninstallerEntry
+            {
+                RawDisplayName = "Bulk Crap Uninstaller",
+                InstallLocation = UninstallToolsGlobalConfig.AppLocation
+            };
+
+            Assert.IsTrue(ShortcutJunk.ShouldKeepShortcutTarget(shortcutTarget, currentApplication));
+        }
+
+        [TestMethod]
+        public void ShouldKeepShortcutTarget_FiltersCurrentApplicationShortcutsForOtherApps()
+        {
+            var shortcutTarget = Path.Combine(UninstallToolsGlobalConfig.AppLocation, "BCUninstaller.exe");
+            var foreignApplication = new ApplicationUninstallerEntry
+            {
+                RawDisplayName = "Other app",
+                InstallLocation = CreateTempDirectory()
+            };
+
+            try
+            {
+                Assert.IsFalse(ShortcutJunk.ShouldKeepShortcutTarget(shortcutTarget, foreignApplication));
+            }
+            finally
+            {
+                CleanupDirectory(foreignApplication.InstallLocation);
+            }
+        }
+
+        private static string CreateTempDirectory()
+        {
+            var path = Path.Combine(Path.GetTempPath(), "BCU_JunkManagerTests_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(path);
+            return path;
+        }
+
+        private static void CleanupDirectory(string path)
+        {
+            if (Directory.Exists(path))
+                Directory.Delete(path, true);
+        }
+
+        private sealed class DummyJunkCreator : IJunkCreator
+        {
+            public static DummyJunkCreator Instance { get; } = new();
+
+            public void Setup(ICollection<ApplicationUninstallerEntry> allUninstallers)
+            {
+            }
+
+            public IEnumerable<IJunkResult> FindJunk(ApplicationUninstallerEntry target)
+            {
+                yield break;
+            }
+
+            public string CategoryName => "Test";
+        }
+    }
+}

--- a/source/UninstallTools/Junk/Finders/Misc/ShortcutJunk.cs
+++ b/source/UninstallTools/Junk/Finders/Misc/ShortcutJunk.cs
@@ -59,8 +59,7 @@ namespace UninstallTools.Junk.Finders.Misc
                     var target = WindowsTools.ResolveShortcut(linkFilename);
 
                     if (string.IsNullOrEmpty(target) ||
-                        PathTools.SubPathIsInsideBasePath(syspath, target, true, true) ||
-                        PathTools.SubPathIsInsideBasePath(UninstallToolsGlobalConfig.AppLocation, target, true, true))
+                        PathTools.SubPathIsInsideBasePath(syspath, target, true, true))
                         continue;
 
                     results.Add(new Shortcut(linkFilename, target));
@@ -135,6 +134,9 @@ namespace UninstallTools.Junk.Finders.Misc
             {
                 foreach (var source in _links)
                 {
+                    if (!ShouldKeepShortcutTarget(source.LinkTarget, target))
+                        continue;
+
                     if (source.LinkTarget.Contains(appId, StringComparison.Ordinal)
                         && source.LinkTarget.Contains("steam", StringComparison.OrdinalIgnoreCase))
                     {
@@ -164,6 +166,9 @@ namespace UninstallTools.Junk.Finders.Misc
 
             foreach (var source in _links)
             {
+                if (!ShouldKeepShortcutTarget(source.LinkTarget, entry))
+                    continue;
+
                 if (source.LinkTarget.Contains(target, StringComparison.InvariantCultureIgnoreCase))
                 {
                     var result = CreateJunkNode(source, entry);
@@ -189,6 +194,12 @@ namespace UninstallTools.Junk.Finders.Misc
             {
                 return LinkTarget;
             }
+        }
+
+        internal static bool ShouldKeepShortcutTarget(string shortcutTarget, ApplicationUninstallerEntry target)
+        {
+            return !PathTools.SubPathIsInsideBasePath(UninstallToolsGlobalConfig.AppLocation, shortcutTarget, true, true)
+                   || JunkManager.IsCurrentApplicationInstallation(target);
         }
     }
 }

--- a/source/UninstallTools/Junk/JunkManager.cs
+++ b/source/UninstallTools/Junk/JunkManager.cs
@@ -23,27 +23,47 @@ namespace UninstallTools.Junk
 
             return RemoveDuplicates(input)
                 .Where(x => JunkDoesNotPointToDirectories(x, prohibitedLocations))
-                .Where(JunkDoesNotPointToSelf);
+                .Where(ShouldKeepSelfJunkResult);
         }
 
         /// <summary>
         /// Make sure that the junk result doesn't point to this application.
         /// </summary>
-        private static bool JunkDoesNotPointToSelf(IJunkResult x)
+        internal static bool ShouldKeepSelfJunkResult(IJunkResult x)
         {
+            if (IsCurrentApplicationInstallation(x?.Application))
+                return true;
+
             if (x is FileSystemJunk fileSystemJunk)
             {
-                return fileSystemJunk.Path == null || 
+                return fileSystemJunk.Path == null ||
                        !fileSystemJunk.Path.FullName.StartsWith(UninstallToolsGlobalConfig.AppLocation, StringComparison.OrdinalIgnoreCase);
             }
 
             if (x is StartupJunkNode startupJunk)
             {
-                return startupJunk.Entry?.CommandFilePath == null || 
+                return startupJunk.Entry?.CommandFilePath == null ||
                        !startupJunk.Entry.CommandFilePath.StartsWith(UninstallToolsGlobalConfig.AppLocation, StringComparison.OrdinalIgnoreCase);
             }
 
             return true;
+        }
+
+        internal static bool IsCurrentApplicationInstallation(ApplicationUninstallerEntry application)
+        {
+            if (application == null)
+                return false;
+
+            return PathPointsToCurrentApplication(application.InstallLocation)
+                   || PathPointsToCurrentApplication(application.UninstallerLocation)
+                   || PathPointsToCurrentApplication(application.UninstallerFullFilename);
+        }
+
+        private static bool PathPointsToCurrentApplication(string path)
+        {
+            return path.IsNotEmpty()
+                   && (PathTools.SubPathIsInsideBasePath(path, UninstallToolsGlobalConfig.AppLocation, true, true)
+                       || PathTools.SubPathIsInsideBasePath(UninstallToolsGlobalConfig.AppLocation, path, true, true));
         }
 
         /// <summary>


### PR DESCRIPTION
Closes #896

## Summary

This PR fixes leftover detection for Bulk Crap Uninstaller itself.

## Changes

- keep the self-protection filter for normal junk scans
- bypass that filter only when the scan target is the current BCU installation
- stop excluding BCU-targeting shortcuts globally during shortcut discovery
- filter those shortcuts later, so they are still hidden for other applications
- add regression tests for self-junk and shortcut handling

## Why

BCU currently suppresses junk results that point to its own install directory.
That is correct for normal scans, but it also hides real leftovers when the user is uninstalling BCU itself.

## Result

BCU can now detect its own install-folder leftovers and related shortcuts during self-uninstall cleanup, without exposing false positives for unrelated applications.
