### PR TITLE
Stabilize icon handle ownership

### DIFF
--- a/source/BulkCrapUninstaller/EntryPoint.cs
+++ b/source/BulkCrapUninstaller/EntryPoint.cs
@@ -136,7 +136,7 @@ namespace BulkCrapUninstaller
                 }
                 else
                 {
-                    CustomMessageBox.ShowDialog(null, new CmbBasicSettings("BCUninstaller is already running", "BCUninstaller is already running", "You can start only one instance of BCUninstaller. Close previous instances and try again. If you don't see the BCUninstaller window or it's not responding, try closing it with Task Manager.", Icon.ExtractAssociatedIcon(location), "OK"));
+                    CustomMessageBox.ShowDialog(null, new CmbBasicSettings("BCUninstaller is already running", "BCUninstaller is already running", "You can start only one instance of BCUninstaller. Close previous instances and try again. If you don't see the BCUninstaller window or it's not responding, try closing it with Task Manager.", DrawingTools.ExtractAssociatedIcon(location), "OK"));
                 }
             }
             catch (Exception ex)

--- a/source/BulkCrapUninstaller/EntryPoint.cs
+++ b/source/BulkCrapUninstaller/EntryPoint.cs
@@ -17,6 +17,7 @@ using Klocman;
 using Klocman.Extensions;
 using Klocman.Forms;
 using Klocman.Forms.Tools;
+using Klocman.Tools;
 using UninstallTools.Dialogs;
 
 namespace BulkCrapUninstaller

--- a/source/BulkCrapUninstallerTests/DrawingToolsTests.cs
+++ b/source/BulkCrapUninstallerTests/DrawingToolsTests.cs
@@ -1,0 +1,26 @@
+using System.Drawing;
+using System.IO;
+using Klocman.Tools;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace BulkCrapUninstallerTests
+{
+    [TestClass]
+    public class DrawingToolsTests
+    {
+        [TestMethod]
+        public void CreateOwnedIconFromHandle_ReturnsUsableClone()
+        {
+            using var sourceIcon = SystemIcons.Application;
+            var handle = sourceIcon.GetHicon();
+
+            using var ownedIcon = DrawingTools.CreateOwnedIconFromHandle(handle);
+            using var stream = new MemoryStream();
+
+            ownedIcon.Save(stream);
+
+            Assert.IsTrue(stream.Length > 0);
+            Assert.AreEqual(sourceIcon.Size, ownedIcon.Size);
+        }
+    }
+}

--- a/source/KlocTools/Tools/DrawingTools.cs
+++ b/source/KlocTools/Tools/DrawingTools.cs
@@ -51,9 +51,30 @@ namespace Klocman.Tools
                 var index = 0;
                 var handle = SafeNativeMethods.ExtractAssociatedIcon(new HandleRef(null, IntPtr.Zero), iconPath, ref index);
                 if (handle != IntPtr.Zero)
-                    return Icon.FromHandle(handle);
+                    return CreateOwnedIconFromHandle(handle);
             }
             return null;
+        }
+
+        /// <summary>
+        /// Clone an icon handle into a managed icon instance and release the original native handle.
+        /// </summary>
+        public static Icon CreateOwnedIconFromHandle(IntPtr handle)
+        {
+            if (handle == IntPtr.Zero)
+                throw new ArgumentException("Icon handle must not be zero", nameof(handle));
+
+            try
+            {
+                using (var temporaryIcon = Icon.FromHandle(handle))
+                {
+                    return (Icon)temporaryIcon.Clone();
+                }
+            }
+            finally
+            {
+                SafeNativeMethods.DestroyIcon(handle);
+            }
         }
 
 
@@ -69,6 +90,10 @@ namespace Klocman.Tools
         {
             [DllImport("shell32.dll", EntryPoint = "ExtractAssociatedIcon", CharSet = CharSet.Auto)]
             internal static extern IntPtr ExtractAssociatedIcon(HandleRef hInst, StringBuilder iconPath, ref int index);
+
+            [DllImport("user32.dll", SetLastError = true)]
+            [return: MarshalAs(UnmanagedType.Bool)]
+            internal static extern bool DestroyIcon(IntPtr hIcon);
         }
 
         public static Color ColorLerp(Color from, Color to, float ratio)

--- a/source/UninstallTools/Factory/ScoopFactory.cs
+++ b/source/UninstallTools/Factory/ScoopFactory.cs
@@ -247,7 +247,7 @@ namespace UninstallTools.Factory
                         {
                             try
                             {
-                                var icon = potentialIcon.EndsWith(".ico", StringComparison.OrdinalIgnoreCase) ? new Icon(potentialIcon) : Icon.ExtractAssociatedIcon(potentialIcon);
+                                var icon = potentialIcon.EndsWith(".ico", StringComparison.OrdinalIgnoreCase) ? new Icon(potentialIcon) : DrawingTools.ExtractAssociatedIcon(potentialIcon);
                                 if (icon == null || icon.Size == Size.Empty) continue;
                                 entry.IconBitmap = icon;
                                 break;

--- a/source/UniversalUninstaller/UninstallSelection.cs
+++ b/source/UniversalUninstaller/UninstallSelection.cs
@@ -24,7 +24,7 @@ namespace UniversalUninstaller
             {
                 /* Fall back to a low quality icon */
                 var handle = Resources.icon.GetHicon();
-                Icon = Icon.FromHandle(handle);
+                Icon = DrawingTools.CreateOwnedIconFromHandle(handle);
 
                 Console.WriteLine(ex);
                 Klocman.LogWriter.WriteMessageToLog(ex.ToString());


### PR DESCRIPTION
Closes #885

## Summary

This PR hardens icon extraction and ownership handling to prevent corrupted or unstable icons.

## Changes

- clone icons extracted from native Win32 handles instead of keeping `Icon.FromHandle(...)` results directly
- always release original icon handles with `DestroyIcon`
- switch remaining direct icon extraction call sites to the safe helper
- add a regression test for owned icon creation

## Why

The current code keeps icons created from native handles without taking ownership correctly.
That can lead to unstable icon state, leaks, or corrupted rendering over time.

## Result

Icons used by BCU are now detached from temporary native handles and remain stable after extraction.
