### PR TITLE
Add invalid-uninstaller view preset

### DIFF
--- a/source/BulkCrapUninstaller/Forms/Windows/MainWindow.Designer.cs
+++ b/source/BulkCrapUninstaller/Forms/Windows/MainWindow.Designer.cs
@@ -150,6 +150,7 @@ namespace BulkCrapUninstaller.Forms
             viewTweaksToolStripMenuItem = new ToolStripMenuItem();
             viewUnregisteredToolStripMenuItem = new ToolStripMenuItem();
             viewUpdatesToolStripMenuItem = new ToolStripMenuItem();
+            viewInvalidToolStripMenuItem = new ToolStripMenuItem();
             viewWindowsFeaturesToolStripMenuItem = new ToolStripMenuItem();
             viewWindowsStoreAppsToolStripMenuItem = new ToolStripMenuItem();
             toolStripSeparator28 = new ToolStripSeparator();
@@ -998,7 +999,7 @@ namespace BulkCrapUninstaller.Forms
             // 
             // filteringToolStripMenuItem
             // 
-            filteringToolStripMenuItem.DropDownItems.AddRange(new ToolStripItem[] { advancedApplicationsToolStripMenuItem, basicApplicationsToolStripMenuItem, systemComponentsToolStripMenuItem, everythingToolStripMenuItem, toolStripSeparator20, automaticallyStartedToolStripMenuItem, onlyWebBrowsersToolStripMenuItem, toolStripSeparator31, viewTweaksToolStripMenuItem, viewUnregisteredToolStripMenuItem, viewUpdatesToolStripMenuItem, viewWindowsFeaturesToolStripMenuItem, viewWindowsStoreAppsToolStripMenuItem, toolStripSeparator28, searchToolStripMenuItem });
+            filteringToolStripMenuItem.DropDownItems.AddRange(new ToolStripItem[] { advancedApplicationsToolStripMenuItem, basicApplicationsToolStripMenuItem, systemComponentsToolStripMenuItem, everythingToolStripMenuItem, toolStripSeparator20, automaticallyStartedToolStripMenuItem, onlyWebBrowsersToolStripMenuItem, toolStripSeparator31, viewTweaksToolStripMenuItem, viewUnregisteredToolStripMenuItem, viewUpdatesToolStripMenuItem, viewInvalidToolStripMenuItem, viewWindowsFeaturesToolStripMenuItem, viewWindowsStoreAppsToolStripMenuItem, toolStripSeparator28, searchToolStripMenuItem });
             filteringToolStripMenuItem.Name = "filteringToolStripMenuItem";
             resources.ApplyResources(filteringToolStripMenuItem, "filteringToolStripMenuItem");
             filteringToolStripMenuItem.DropDownOpening += filteringToolStripMenuItem_DropDownOpening;
@@ -1062,15 +1063,21 @@ namespace BulkCrapUninstaller.Forms
             viewUnregisteredToolStripMenuItem.Name = "viewUnregisteredToolStripMenuItem";
             resources.ApplyResources(viewUnregisteredToolStripMenuItem, "viewUnregisteredToolStripMenuItem");
             viewUnregisteredToolStripMenuItem.Click += viewUnregisteredToolStripMenuItem_Click;
-            // 
+            //
             // viewUpdatesToolStripMenuItem
-            // 
+            //
             viewUpdatesToolStripMenuItem.Name = "viewUpdatesToolStripMenuItem";
             resources.ApplyResources(viewUpdatesToolStripMenuItem, "viewUpdatesToolStripMenuItem");
             viewUpdatesToolStripMenuItem.Click += viewUpdatesToolStripMenuItem_Click;
-            // 
+            //
+            // viewInvalidToolStripMenuItem
+            //
+            viewInvalidToolStripMenuItem.Name = "viewInvalidToolStripMenuItem";
+            resources.ApplyResources(viewInvalidToolStripMenuItem, "viewInvalidToolStripMenuItem");
+            viewInvalidToolStripMenuItem.Click += viewInvalidToolStripMenuItem_Click;
+            //
             // viewWindowsFeaturesToolStripMenuItem
-            // 
+            //
             viewWindowsFeaturesToolStripMenuItem.Name = "viewWindowsFeaturesToolStripMenuItem";
             resources.ApplyResources(viewWindowsFeaturesToolStripMenuItem, "viewWindowsFeaturesToolStripMenuItem");
             viewWindowsFeaturesToolStripMenuItem.Click += viewWindowsFeaturesToolStripMenuItem_Click;
@@ -1751,6 +1758,7 @@ namespace BulkCrapUninstaller.Forms
         private ToolStripSeparator toolStripSeparator3;
         private ToolStripMenuItem runToolStripMenuItem;
         private ToolStripMenuItem viewUpdatesToolStripMenuItem;
+        private ToolStripMenuItem viewInvalidToolStripMenuItem;
         private ToolStripMenuItem targetMenuItem;
         private ToolStripSeparator toolStripSeparator25;
         private ToolStripSeparator toolStripSeparator26;

--- a/source/BulkCrapUninstaller/Forms/Windows/MainWindow.cs
+++ b/source/BulkCrapUninstaller/Forms/Windows/MainWindow.cs
@@ -1614,6 +1614,13 @@ namespace BulkCrapUninstaller.Forms
             filterEditor1.Search(true.ToString(), ComparisonMethod.Equals, nameof(ApplicationUninstallerEntry.IsUpdate));
         }
 
+        private void viewInvalidToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            everythingToolStripMenuItem_Click(sender, e);
+            _setMan.Selected.Settings.AdvancedTestInvalid = true;
+            filterEditor1.Search(false.ToString(), ComparisonMethod.Equals, nameof(ApplicationUninstallerEntry.IsValid));
+        }
+
         private void filterEditor1_FocusSearchTarget(object sender, EventArgs e)
         {
             uninstallerObjectListView.Focus();
@@ -1768,6 +1775,7 @@ namespace BulkCrapUninstaller.Forms
 
             viewUnregisteredToolStripMenuItem.Enabled = isSimpleFiltering;
             viewUpdatesToolStripMenuItem.Enabled = isSimpleFiltering;
+            viewInvalidToolStripMenuItem.Enabled = isSimpleFiltering;
             viewWindowsStoreAppsToolStripMenuItem.Enabled = isSimpleFiltering;
             viewWindowsFeaturesToolStripMenuItem.Enabled = isSimpleFiltering;
         }

--- a/source/BulkCrapUninstaller/Forms/Windows/MainWindow.resx
+++ b/source/BulkCrapUninstaller/Forms/Windows/MainWindow.resx
@@ -1492,6 +1492,12 @@
   <data name="viewUpdatesToolStripMenuItem.Text" xml:space="preserve">
     <value>View Updates</value>
   </data>
+  <data name="viewInvalidToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>213, 22</value>
+  </data>
+  <data name="viewInvalidToolStripMenuItem.Text" xml:space="preserve">
+    <value>View Invalid</value>
+  </data>
   <data name="viewWindowsFeaturesToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>213, 22</value>
   </data>
@@ -2844,6 +2850,12 @@
     <value>viewUpdatesToolStripMenuItem</value>
   </data>
   <data name="&gt;&gt;viewUpdatesToolStripMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;viewInvalidToolStripMenuItem.Name" xml:space="preserve">
+    <value>viewInvalidToolStripMenuItem</value>
+  </data>
+  <data name="&gt;&gt;viewInvalidToolStripMenuItem.Type" xml:space="preserve">
     <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;viewWindowsFeaturesToolStripMenuItem.Name" xml:space="preserve">


### PR DESCRIPTION
Closes #878

## Summary

This PR adds a dedicated filtering preset for invalid uninstallers.

## Changes

- add a new `View Invalid` entry under the Filtering menu
- make the preset start from the `Everything` view so invalid entries are not hidden by other simple filters
- enable invalid highlighting before applying the filter
- filter the list to entries where `IsValid == false`

## Why

Users currently see invalid uninstallers as grey rows, but there is no direct simple-filter preset to view only those entries.
This makes grey/invalid uninstallers directly filterable from the UI.

## Result

Users can now quickly switch to an invalid-only view from the Filtering menu without needing advanced filters.
