### PR TITLE
Fix: Use Directory.GetLastWriteTime for install date fallback

### DIFF
--- a/source/UninstallTools/Factory/InfoAdders/InstallDateAdder.cs
+++ b/source/UninstallTools/Factory/InfoAdders/InstallDateAdder.cs
@@ -17,7 +17,7 @@ namespace UninstallTools.Factory.InfoAdders
                 if (File.Exists(target.UninstallerFullFilename))
                     target.InstallDate = File.GetCreationTime(target.UninstallerFullFilename);
                 else if (Directory.Exists(target.InstallLocation))
-                    target.InstallDate = Directory.GetCreationTime(target.InstallLocation);
+                    target.InstallDate = Directory.GetLastWriteTime(target.InstallLocation);
             }
             catch
             {


### PR DESCRIPTION
## Problem
When InstallDate is not available in the registry (common for non-MSI installers like Google Web Designer), BCU falls back to using file/directory creation times. However, creation times often reflect the original build date rather than the installation date.

## Solution
This fix improves the fallback logic to use Directory.GetLastWriteTime instead of GetCreationTime. The directory's last write time is updated when files are added during installation, providing a more accurate approximation of the actual installation date.

## Testing
- Preserves existing behavior for applications with valid InstallDate in registry
- For applications without InstallDate (like Google Web Designer v16.4.1 from the issue), now uses the directory's last modification time instead of creation time
- This should result in installation dates much closer to the actual installation date rather than binary build dates

Fixes #886

@Klocman Please review this fix.