### PR TITLE
Guard startup uninstall list loading

### DIFF
--- a/source/BulkCrapUninstaller/Forms/Windows/MainWindow.cs
+++ b/source/BulkCrapUninstaller/Forms/Windows/MainWindow.cs
@@ -1435,8 +1435,7 @@ namespace BulkCrapUninstaller.Forms
             {
                 _setMan.LoadSorting();
 
-                var args = Environment.GetCommandLineArgs();
-                var dir = args.Skip(1).FirstOrDefault();
+                var dir = StartupArgumentTools.GetStartupUninstallListPath(Environment.GetCommandLineArgs());
                 if (!string.IsNullOrEmpty(dir))
                 {
                     try

--- a/source/BulkCrapUninstaller/Functions/Tools/StartupArgumentTools.cs
+++ b/source/BulkCrapUninstaller/Functions/Tools/StartupArgumentTools.cs
@@ -1,0 +1,34 @@
+/*
+    Copyright (c) 2017 Marcin Szeniak (https://github.com/Klocman/)
+    Apache License Version 2.0
+*/
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace BulkCrapUninstaller.Functions.Tools
+{
+    public static class StartupArgumentTools
+    {
+        public static string GetStartupUninstallListPath(IEnumerable<string> commandLineArgs)
+        {
+            var candidate = commandLineArgs?.Skip(1).FirstOrDefault();
+            if (string.IsNullOrWhiteSpace(candidate))
+                return null;
+
+            try
+            {
+                if (!candidate.EndsWith(".bcul", StringComparison.OrdinalIgnoreCase))
+                    return null;
+
+                return File.Exists(candidate) ? candidate : null;
+            }
+            catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/source/BulkCrapUninstallerTests/Functions/StartupArgumentToolsTests.cs
+++ b/source/BulkCrapUninstallerTests/Functions/StartupArgumentToolsTests.cs
@@ -1,0 +1,55 @@
+using System;
+using System.IO;
+using BulkCrapUninstaller.Functions.Tools;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace BulkCrapUninstallerTests.Functions
+{
+    [TestClass]
+    public class StartupArgumentToolsTests
+    {
+        [TestMethod]
+        public void GetStartupUninstallListPath_ReturnsNullWhenThereAreNoArguments()
+        {
+            var result = StartupArgumentTools.GetStartupUninstallListPath(Array.Empty<string>());
+
+            Assert.IsNull(result);
+        }
+
+        [TestMethod]
+        public void GetStartupUninstallListPath_ReturnsNullForNonBculArgument()
+        {
+            var result = StartupArgumentTools.GetStartupUninstallListPath(new[] { "BCUninstaller.exe", "/setup" });
+
+            Assert.IsNull(result);
+        }
+
+        [TestMethod]
+        public void GetStartupUninstallListPath_ReturnsNullForMissingBculFile()
+        {
+            var result = StartupArgumentTools.GetStartupUninstallListPath(new[] { "BCUninstaller.exe", @"C:\missing\Default.bcul" });
+
+            Assert.IsNull(result);
+        }
+
+        [TestMethod]
+        public void GetStartupUninstallListPath_ReturnsExistingBculPath()
+        {
+            var tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".bcul");
+
+            try
+            {
+                File.WriteAllText(tempPath, "<UninstallList />");
+
+                var result = StartupArgumentTools.GetStartupUninstallListPath(new[] { "BCUninstaller.exe", tempPath });
+
+                Assert.AreEqual(tempPath, result);
+            }
+            finally
+            {
+                if (File.Exists(tempPath))
+                    File.Delete(tempPath);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #775

## Summary

Prevent BCU from trying to open arbitrary startup arguments as uninstall lists.

## Changes

- only treat the first startup argument as an uninstall list when it is an existing `.bcul` file
- move the startup argument validation into a dedicated helper
- add regression tests for valid, missing, and non-`.bcul` startup arguments

## Why

On startup, BCU was attempting to load the first command-line argument as an uninstall list without checking whether it was actually a `.bcul` file. If the app was launched with some other argument, this could trigger the XML deserialization error reported in #775.