### PR TITLE
Clarify uninstall progress - leftover scan next step

### DIFF
--- a/source/BulkCrapUninstaller/Forms/Windows/UninstallProgressWindow.cs
+++ b/source/BulkCrapUninstaller/Forms/Windows/UninstallProgressWindow.cs
@@ -146,7 +146,7 @@ namespace BulkCrapUninstaller.Forms
                 {
                     _sleepTimePassed = 0;
                     if (_currentTargetStatus.Finished)
-                        label1.Text = Localisable.UninstallProgressWindow_TaskDone;
+                        label1.Text = Localisable.UninstallProgressWindow_TaskDoneNextStep;
                 }
             };
         }
@@ -217,7 +217,7 @@ namespace BulkCrapUninstaller.Forms
                 }
             }
 
-            label1.Text = Localisable.UninstallProgressWindow_TaskDone;
+            label1.Text = Localisable.UninstallProgressWindow_TaskDoneNextStep;
             progressBar1.Value = progressBar1.Maximum;
             buttonClose.Text = Buttons.ButtonClose;
             pictureBox1.Image = Resources.check;

--- a/source/BulkCrapUninstaller/Properties/Localisable.Designer.cs
+++ b/source/BulkCrapUninstaller/Properties/Localisable.Designer.cs
@@ -1945,6 +1945,15 @@ namespace BulkCrapUninstaller.Properties {
                 return ResourceManager.GetString("UninstallProgressWindow_TaskDone", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Task finished. Close this window to continue; BCU may ask to scan for leftovers..
+        /// </summary>
+        internal static string UninstallProgressWindow_TaskDoneNextStep {
+            get {
+                return ResourceManager.GetString("UninstallProgressWindow_TaskDoneNextStep", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Uninstalling.

--- a/source/BulkCrapUninstaller/Properties/Localisable.de.resx
+++ b/source/BulkCrapUninstaller/Properties/Localisable.de.resx
@@ -466,6 +466,10 @@ Möchten Sie für diese Elemente die Standard Uninstaller verwenden oder sollen 
     <value>Task abgeschlossen</value>
     <comment>Shown on the status bar</comment>
   </data>
+  <data name="UninstallProgressWindow_TaskDoneNextStep" xml:space="preserve">
+    <value>Task abgeschlossen. Schließen Sie dieses Fenster, um fortzufahren; BCU fragt möglicherweise, ob nach Überresten gesucht werden soll.</value>
+    <comment>Shown on the status bar after uninstallers finish</comment>
+  </data>
   <data name="UninstallProgressWindow_Uninstalling" xml:space="preserve">
     <value>Deinstallation</value>
     <comment>Shown on the status bar</comment>

--- a/source/BulkCrapUninstaller/Properties/Localisable.es.resx
+++ b/source/BulkCrapUninstaller/Properties/Localisable.es.resx
@@ -313,6 +313,10 @@ The lists are separated by a single newline.</comment>
     <value>Tarea finalizada</value>
     <comment>Shown on the status bar</comment>
   </data>
+  <data name="UninstallProgressWindow_TaskDoneNextStep" xml:space="preserve">
+    <value>Tarea finalizada. Cierre esta ventana para continuar; BCU puede preguntar si desea buscar restos.</value>
+    <comment>Shown on the status bar after uninstallers finish</comment>
+  </data>
   <data name="UninstallProgressWindow_Uninstalling" xml:space="preserve">
     <value>Desinstalando</value>
     <comment>Shown on the status bar</comment>

--- a/source/BulkCrapUninstaller/Properties/Localisable.fr.resx
+++ b/source/BulkCrapUninstaller/Properties/Localisable.fr.resx
@@ -464,6 +464,10 @@ Voulez-vous utiliser les désinstalleurs "causants" pour ces éléments, ou doiv
     <value>Tâche terminée</value>
     <comment>Shown on the status bar</comment>
   </data>
+  <data name="UninstallProgressWindow_TaskDoneNextStep" xml:space="preserve">
+    <value>Tâche terminée. Fermez cette fenêtre pour continuer ; BCU peut vous proposer de rechercher les résidus.</value>
+    <comment>Shown on the status bar after uninstallers finish</comment>
+  </data>
   <data name="UninstallProgressWindow_Uninstalling" xml:space="preserve">
     <value>Désinstallation</value>
     <comment>Shown on the status bar</comment>

--- a/source/BulkCrapUninstaller/Properties/Localisable.it.resx
+++ b/source/BulkCrapUninstaller/Properties/Localisable.it.resx
@@ -466,6 +466,10 @@ Vuoi utilizzare i disinstallatori guidati per questi elementi? O preferisci sian
     <value>Attività completata</value>
     <comment>Shown on the status bar</comment>
   </data>
+  <data name="UninstallProgressWindow_TaskDoneNextStep" xml:space="preserve">
+    <value>Attività completata. Chiudi questa finestra per continuare; BCU potrebbe chiedere di cercare residui.</value>
+    <comment>Shown on the status bar after uninstallers finish</comment>
+  </data>
   <data name="UninstallProgressWindow_Uninstalling" xml:space="preserve">
     <value>Disinstallazione</value>
     <comment>Shown on the status bar</comment>

--- a/source/BulkCrapUninstaller/Properties/Localisable.nl.resx
+++ b/source/BulkCrapUninstaller/Properties/Localisable.nl.resx
@@ -622,6 +622,10 @@ Van tijd tot tijd zou u moeten controleren of een van de de-installers niet is g
     <value>Taak voltooid</value>
     <comment>Shown on the status bar</comment>
   </data>
+  <data name="UninstallProgressWindow_TaskDoneNextStep" xml:space="preserve">
+    <value>Taak voltooid. Sluit dit venster om door te gaan; BCU kan vragen om naar restanten te zoeken.</value>
+    <comment>Shown on the status bar after uninstallers finish</comment>
+  </data>
   <data name="UninstallProgressWindow_Uninstalling" xml:space="preserve">
     <value>De-installatie</value>
     <comment>Shown on the status bar</comment>

--- a/source/BulkCrapUninstaller/Properties/Localisable.resx
+++ b/source/BulkCrapUninstaller/Properties/Localisable.resx
@@ -466,6 +466,10 @@ Do you want to use "loud" uninstallers for those items, or should they be remove
     <value>Task finished</value>
     <comment>Shown on the status bar</comment>
   </data>
+  <data name="UninstallProgressWindow_TaskDoneNextStep" xml:space="preserve">
+    <value>Task finished. Close this window to continue; BCU may ask to scan for leftovers.</value>
+    <comment>Shown on the status bar after uninstallers finish</comment>
+  </data>
   <data name="UninstallProgressWindow_Uninstalling" xml:space="preserve">
     <value>Uninstalling</value>
     <comment>Shown on the status bar</comment>


### PR DESCRIPTION
﻿Fixes #481.

Updates the uninstall progress finished state to clarify that closing the progress window continues the workflow and may prompt for leftover scanning. 
Added the new status text to the default resources and localized resources. 
German translated by myself, the others by using Translation AI for: Spanish, French, Italian, and Dutch.


Testing:
- Rebuilt `source\BulkCrapUninstaller\BulkCrapUninstaller.csproj` with VS MSBuild.
- Verified the new resource key is present in the default resource file and the selected localized resource files.
